### PR TITLE
change ubuntu 16.04 to 17.10

### DIFF
--- a/system_administration/01_SetupArkNode.md
+++ b/system_administration/01_SetupArkNode.md
@@ -13,7 +13,7 @@ and securing the Ark Network.
 ## Recommended Specifications
 - 2 CPU Cores+
 - 8GB Ram+
-- Ubuntu 16.04
+- Ubuntu 17.10
 - 40GB+ SSD
 
 ## Prerequisite Setup
@@ -28,7 +28,7 @@ server when running a delegate nodes. These nodes are the security of our networ
 and their uptime is of most importance in making sure the network runs smoothly.
 
 The recommended specifications are what we would consider the minimum specifications
-for delegate nodes. Smaller nodes are fine for relays or development purposes. We recommend using Ubuntu 16.04 however you are free to use any version of Linux you're comfortable with. These guides will use debian flavored Linux variants though.
+for delegate nodes. Smaller nodes are fine for relays or development purposes. We recommend using Ubuntu 17.10 however you are free to use any version of Linux you're comfortable with. These guides will use debian flavored Linux variants though.
 
 With each provider, the setup process for creating a new virtual server is going to
 be different. If choosing one of the listed providers, we have created quick

--- a/system_administration/02_SecureYourArkNode.md
+++ b/system_administration/02_SecureYourArkNode.md
@@ -128,7 +128,7 @@ exit
 Port knocking is a technique used which obscures the port you're actually connecting on to prevent port scanning by opening and closing it when you need it. We will use a series of ports to essentially "knock" and your server will open your configured port for you to connect on by listening for connection attempts on those ports in a specific order.
 
 #### Disable UFW
-By default UFW comes enabled with Ubuntu 16.04. If you get `ufw command not found` then run
+By default UFW comes enabled with Ubuntu 17.10. If you get `ufw command not found` then run
 
 ```
 sudo apt-get install ufw
@@ -232,7 +232,7 @@ Install a client for your operating system to make knocking easier. There even a
 
 After knocking your port will remain open until you send the closing knock sequence.
 
-##### Ubuntu 16.04
+##### Ubuntu 17.10
 ```
 sudo apt-get install knockd
 ```


### PR DESCRIPTION
Since Ubuntu 16.04 and 16.10 aren't supported anymore we should also upgrade the docs to the latest supported version of Ubuntu.

I'm running all my nodes on Ubuntu 17.10 and have no problems at all.