### PR TITLE
docs(public-rest-api): update api urls

### DIFF
--- a/docs/api/public-rest-api/getting-started.md.blade.php
+++ b/docs/api/public-rest-api/getting-started.md.blade.php
@@ -10,8 +10,8 @@ All HTTP requests have to be sent with the `Content-Type: application/json` head
 
 This is the reference guide for the Public API. This API exposes all resources and data provided by an ARK Core node; and is the preferred way of interacting with the ARK network. Note that each node has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as an official explorer to ensure you are in sync.
 
- * Mainnet: [https://explorer.ark.io](https://explorer.ark.io)
- * Devnet: [https://dexplorer.ark.io](https://dexplorer.ark.io)
+* Mainnet: [https://explorer.ark.io](https://explorer.ark.io)
+* Devnet: [https://dexplorer.ark.io](https://dexplorer.ark.io)
 
 > If you have any problems or requests please [open an issue](https://github.com/ARKEcosystem/core/issues/new/choose).
 
@@ -23,7 +23,7 @@ Requests that return multiple items will be paginated to 100 items by default. Y
 
 If you are not running a relay yourself you can test API calls using:
 
- * Mainnet: [https://api.ark.io/api](https://api.ark.io/api)
- * Devnet: [https://dwallets.ark.io/api](https://dwallets.ark.io/api)
+* Mainnet: [https://api.ark.io/api](https://api.ark.io/api)
+* Devnet: [https://dwallets.ark.io/api](https://dwallets.ark.io/api)
 
 Happy developing!

--- a/docs/api/public-rest-api/getting-started.md.blade.php
+++ b/docs/api/public-rest-api/getting-started.md.blade.php
@@ -18,4 +18,9 @@ Requests that return multiple items will be paginated to 100 items by default. Y
 
 ## Public Testing Relay
 
-If you are not running a relay yourself you can use [https://api.ark.io/api/](https://api.ark.io/api/) to test API calls. Happy developing!
+If you are not running a relay yourself you can test API calls using:
+
+ - For mainnet: [https://api.ark.io/api](https://api.ark.io/api) (explorer: [https://explorer.ark.io/](https://explorer.ark.io/))
+ - For devnet: [https://dwallets.ark.io/api](https://dwallets.ark.io/api) (explorer: [https://dexplorer.ark.io/](https://dexplorer.ark.io/))
+
+Happy developing!

--- a/docs/api/public-rest-api/getting-started.md.blade.php
+++ b/docs/api/public-rest-api/getting-started.md.blade.php
@@ -8,7 +8,7 @@ title: Getting Started
 All HTTP requests have to be sent with the `Content-Type: application/json` header. If the header is not present it will result in malformed responses or request rejections.
 </x-alert>
 
-This is the reference guide for the Public API. This API exposes all resources and data provided by an ARK Core node; and is the preferred way of interacting with the ARK network. Note that each node has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as an official to ensure you are in sync.
+This is the reference guide for the Public API. This API exposes all resources and data provided by an ARK Core node; and is the preferred way of interacting with the ARK network. Note that each node has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as an official explorer to ensure you are in sync.
 
  * Mainnet: [https://explorer.ark.io](https://explorer.ark.io)
  * Devnet: [https://dexplorer.ark.io](https://dexplorer.ark.io)

--- a/docs/api/public-rest-api/getting-started.md.blade.php
+++ b/docs/api/public-rest-api/getting-started.md.blade.php
@@ -8,7 +8,10 @@ title: Getting Started
 All HTTP requests have to be sent with the `Content-Type: application/json` header. If the header is not present it will result in malformed responses or request rejections.
 </x-alert>
 
-This is the reference guide for the Public API. This API exposes all resources and data provided by an ARK Core node; and is the preferred way of interacting with the ARK network. Note that each node has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as the official [explorer](https://explorer.ark.io:8443/api) to ensure you are in sync.
+This is the reference guide for the Public API. This API exposes all resources and data provided by an ARK Core node; and is the preferred way of interacting with the ARK network. Note that each node has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as an official to ensure you are in sync.
+
+ * Mainnet: [https://explorer.ark.io](https://explorer.ark.io)
+ * Devnet: [https://dexplorer.ark.io](https://dexplorer.ark.io)
 
 > If you have any problems or requests please [open an issue](https://github.com/ARKEcosystem/core/issues/new/choose).
 
@@ -20,7 +23,7 @@ Requests that return multiple items will be paginated to 100 items by default. Y
 
 If you are not running a relay yourself you can test API calls using:
 
- - For mainnet: [https://api.ark.io/api](https://api.ark.io/api) (explorer: [https://explorer.ark.io/](https://explorer.ark.io/))
- - For devnet: [https://dwallets.ark.io/api](https://dwallets.ark.io/api) (explorer: [https://dexplorer.ark.io/](https://dexplorer.ark.io/))
+ * Mainnet: [https://api.ark.io/api](https://api.ark.io/api)
+ * Devnet: [https://dwallets.ark.io/api](https://dwallets.ark.io/api)
 
 Happy developing!


### PR DESCRIPTION
## Summary

Add a link to the devnet public API endpoint (https://dwallets.ark.io/api). Asked a lot on Discord (as it should be).

Added explorer links too.

## Checklist

- [x] Documentation _(if necessary)_
- [x] Ready to be merged
