### PR TITLE
docs(public-rest-api): update 'node/fees' endpoint

### DIFF
--- a/docs/api/public-rest-api/endpoints/specs/node/fees.json
+++ b/docs/api/public-rest-api/endpoints/specs/node/fees.json
@@ -1,13 +1,12 @@
 {
     "title": "Retrieve the Fee Statistics",
-    "description": "Used to access a Node's fee statistics.",
+    "description": "Used to access a Node’s fee statistics. By default, this endpoint returns calculations based on the 20 most-recent transactions for each type. Also note while using the `days` query that statistics may not be available for all transaction-types over a given period of time.",
     "method": "GET",
     "path": "node/fees",
     "parameters": {
         "days": {
             "type": "query",
-            "description": "The number of days which will be regarded.",
-            "example": 7,
+            "description": "The number of days [1-30] to search.",
             "rules": ["nullable", "integer"]
         }
     }


### PR DESCRIPTION

## Summary

Update the `node/fees` endpoint doc to match the "last 20 of each" change ( https://github.com/ArkEcosystem/core/pull/4328 & https://github.com/ArkEcosystem/core/pull/4330).

#

```diff
- Used to access a Node's fee statistics.
```
> Used to access a Node’s fee statistics. By default, this endpoint returns calculations based on the 20 most-recent transactions for each type. Also note while using the `days` query that statistics may not be available for all transaction-types over a given period of time.

```diff
- The number of days which will be regarded.
```
> The number of days [1-30] to search.

## Checklist

- [x] Ready to be merged
