### PR TITLE
docs(public-rest-api): fix spec file typos

### DIFF
--- a/docs/api/public-rest-api/endpoints/specs/blocks/search.json
+++ b/docs/api/public-rest-api/endpoints/specs/blocks/search.json
@@ -78,7 +78,7 @@
         },
         "numberOfTransactions": {
             "type": "body",
-            "description": "Ranage for number of transactions contained in the block.",
+            "description": "Range for number of transactions contained in the block.",
             "rules": ["nullable", "integer"]
         },
         "numberOfTransactions.from": {

--- a/docs/api/public-rest-api/endpoints/specs/entities/all.json
+++ b/docs/api/public-rest-api/endpoints/specs/entities/all.json
@@ -48,7 +48,7 @@
         },
         "isResigned": {
             "type": "query",
-            "description": "The flag to indicate that resigned entites should be retrieved.",
+            "description": "The flag to indicate that resigned entities should be retrieved.",
             "rules": [
                 "nullable",
                 "boolean"


### PR DESCRIPTION

## Summary

Last run-through didn't catch `.json` spec files.

- [ark.dev docs wordlist also updated (ark-docs-wordlist.json)](https://gist.githubusercontent.com/sleepdefic1t/157a2ca89c81e4d88bc84f885dfaf0b4/raw/d3fbe413bee464d196b25de098a9a37b62efe3d9/ark-docs-wordlist.json)

## Checklist

- [x] Ready to be merged
