### PR TITLE
fix(psdk): xrp livewire link

### DIFF
--- a/docs/platform-sdk/coins/xrp.md.blade.php
+++ b/docs/platform-sdk/coins/xrp.md.blade.php
@@ -18,7 +18,7 @@ yarn add @arkecosystem/platform-sdk-xrp
 
 ## Specification
 
-<livewire:coin-spec spec="platform-sdk/coins/specs/ada.json" />
+<livewire:coin-spec spec="platform-sdk/coins/specs/xrp.json" />
 
 ## Security
 


### PR DESCRIPTION

## Summary

Fix incorrect XRP Livewire `coin-spec` embed link: `ada` -> `xrp`.

## Checklist

- [x] Ready to be merged
