### PR TITLE
chore(dw2): add missing installation title

### DIFF
--- a/docs/desktop-wallet/user-guides/installation.md.blade.php
+++ b/docs/desktop-wallet/user-guides/installation.md.blade.php
@@ -1,3 +1,8 @@
+
+---
+title: Installation
+---
+
 # Installation
 
 To download the application, you can visit the link below and select the appropriate release for your computer's platform. The ARK Desktop Wallet is available for Windows, Mac, and Linux.


### PR DESCRIPTION

## Summary

Add missing meta-title on the Desktop Wallet v2 installation page.

## Checklist

- [x] Ready to be merged
