### PR TITLE
docs(core): clarify install step

### DIFF
--- a/docs/core/getting-started/installation.md.blade.php
+++ b/docs/core/getting-started/installation.md.blade.php
@@ -178,12 +178,12 @@ Would you like to configure the database? [y/N]:
 
 Press `y` and confirm with `enter`.
 
-You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing "ark_network" with the network you plan to operate on (eg. ark_mainnet, ark_devnet, ark_testnet):
+You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing "ark_network" with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
 
 ```bash
 Enter the database username: ark
 Enter the database password: password
-Enter the database name: ark_network
+Enter the database name: <network_name>
 ```
 
 This will create a PostgreSQL role and database to be used for storing blockchain data.

--- a/docs/core/getting-started/installation.md.blade.php
+++ b/docs/core/getting-started/installation.md.blade.php
@@ -178,7 +178,7 @@ Would you like to configure the database? [y/N]:
 
 Press `y` and confirm with `enter`.
 
-You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing "ark_network" with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
+You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing `<network_name>` with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
 
 ```bash
 Enter the database username: ark

--- a/docs/core/getting-started/installation.md.blade.php
+++ b/docs/core/getting-started/installation.md.blade.php
@@ -178,13 +178,19 @@ Would you like to configure the database? [y/N]:
 
 Press `y` and confirm with `enter`.
 
-You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing `<network_name>` with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
+---
+
+Input the database credentials of your choosing.
 
 ```bash
 Enter the database username: ark
 Enter the database password: password
-Enter the database name: <network_name>
+Enter the database name: <network_name> # your chosen network name
 ```
+
+<x-alert type="warning">
+Replace `<network_name>` with the appropriate custom or pre-defined network name (e.g. '**ark_mainnet**', '**ark_devnet**', '**ark_testnet**').
+</x-alert>
 
 This will create a PostgreSQL role and database to be used for storing blockchain data.
 

--- a/docs/core/getting-started/production-setup/core-server-setup.md.blade.php
+++ b/docs/core/getting-started/production-setup/core-server-setup.md.blade.php
@@ -192,12 +192,12 @@ Would you like to configure the database? [y/N]:
 
 Press `y` and confirm with `enter`.
 
-You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing "ark_network" with the network you plan to operate on (eg. ark_mainnet, ark_devnet, ark_testnet):
+You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing `<network_name>` with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
 
 ```bash
 Enter the database username: ark
 Enter the database password: password
-Enter the database name: ark_network
+Enter the database name: <network_name>
 ```
 
 This will create a PostgreSQL role and database to be used for storing blockchain data. That’s it, you are all set!

--- a/docs/core/getting-started/production-setup/core-server-setup.md.blade.php
+++ b/docs/core/getting-started/production-setup/core-server-setup.md.blade.php
@@ -192,13 +192,19 @@ Would you like to configure the database? [y/N]:
 
 Press `y` and confirm with `enter`.
 
-You can input any custom database credentials that you want to use, or you can use the one provided below, by replacing `<network_name>` with the network you plan to operate on (eg. **ark_mainnet**, **ark_devnet**, **ark_testnet**):
+---
+
+Input the database credentials of your choosing.
 
 ```bash
 Enter the database username: ark
 Enter the database password: password
-Enter the database name: <network_name>
+Enter the database name: <network_name> # your chosen network name
 ```
+
+<x-alert type="warning">
+Replace `<network_name>` with the appropriate custom or pre-defined network name (e.g. '**ark_mainnet**', '**ark_devnet**', '**ark_testnet**').
+</x-alert>
 
 This will create a PostgreSQL role and database to be used for storing blockchain data. That’s it, you are all set!
 


### PR DESCRIPTION

## Summary

Clarify that a particular database network name should be used in the Core Doc’s installation guide.

## Checklist

- [x] Ready to be merged
