### PR TITLE
fix(docs): use correct 'ark' case

### DIFF
--- a/docs/api/public-rest-api/getting-started.md.blade.php
+++ b/docs/api/public-rest-api/getting-started.md.blade.php
@@ -13,7 +13,7 @@ This is the reference guide for the Public API. This API exposes all resources a
 * Mainnet: [https://explorer.ark.io](https://explorer.ark.io)
 * Devnet: [https://dexplorer.ark.io](https://dexplorer.ark.io)
 
-> If you have any problems or requests please [open an issue](https://github.com/ARKEcosystem/core/issues/new/choose).
+> If you have any problems or requests please [open an issue](https://github.com/ArkEcosystem/core/issues/new/choose).
 
 ## Pagination
 

--- a/docs/core/development/api.md.blade.php
+++ b/docs/core/development/api.md.blade.php
@@ -7,7 +7,7 @@ title: Development - Creating API Servers
 A common use-case for a module is that you process some data from within core and want to make use of that data with an external application. The easiest way to do this is through an HTTP server that exposes an API from which you request the data.
 
 <x-alert type="info">
-Core provides a package called [core-http-utils](https://github.com/ARKEcosystem/core/tree/develop/packages/core-http-utils/src) which provides everything you will need to run an HTTP server with modules. Core uses [hapi](https://hapijs.com/) for all its HTTP based services as it enables developers to focus on writing reusable application logic instead of spending time building infrastructure.
+Core provides a package called [core-http-utils](https://github.com/ArkEcosystem/core/tree/develop/packages/core-http-utils/src) which provides everything you will need to run an HTTP server with modules. Core uses [hapi](https://hapijs.com/) for all its HTTP based services as it enables developers to focus on writing reusable application logic instead of spending time building infrastructure.
 </x-alert>
 
 ## Step 0: Create A New Module From A Template

--- a/docs/core/development/docker.md.blade.php
+++ b/docs/core/development/docker.md.blade.php
@@ -48,8 +48,8 @@ The code sample below downloads the needed files from our official [GitHub Core 
 NETWORK=devnet
 mkdir ~/$NETWORK
 cd ~/$NETWORK
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/$NETWORK/docker-compose.yml
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/$NETWORK/$NETWORK.env
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/$NETWORK/docker-compose.yml
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/$NETWORK/$NETWORK.env
 ```
 
 ### Running a Relay Node

--- a/docs/core/overview/cryptography.md.blade.php
+++ b/docs/core/overview/cryptography.md.blade.php
@@ -24,9 +24,9 @@ To promote usability while also maintaining security, ARK passphrases are implem
 
 ![Cryptography overview](/storage/docs/docs/core/assets/overview_nologo.svg)
 
-The following examples will be using test-fixtures from the [ARK Core](https://github.com/ARKEcosystem/core/) repo on [GitHub](https://github.com/ARKEcosystem/).
+The following examples will be using test-fixtures from the [ARK Core](https://github.com/ArkEcosystem/core/) repo on [GitHub](https://github.com/ArkEcosystem/).
 
-[Identities Test Fixtures:](https://github.com/ARKEcosystem/core/blob/develop/__tests__/unit/crypto/identities/fixture.json)
+[Identities Test Fixtures:](https://github.com/ArkEcosystem/core/blob/develop/__tests__/unit/crypto/identities/fixture.json)
 
 ```javascript
 {
@@ -40,7 +40,7 @@ The following examples will be using test-fixtures from the [ARK Core](https://g
 }
 ```
 
-[Message Test Fixtures:](https://github.com/ARKEcosystem/core/blob/develop/__tests__/unit/crypto/utils/message.test.ts)
+[Message Test Fixtures:](https://github.com/ArkEcosystem/core/blob/develop/__tests__/unit/crypto/utils/message.test.ts)
 
 ```typescript
 const fixture = {

--- a/docs/core/overview/models.md.blade.php
+++ b/docs/core/overview/models.md.blade.php
@@ -38,7 +38,7 @@ Blocks are the core unit of any given blockchain. In ARK, blocks contain a group
 
 ## Transaction
 
-Transactions are the heart of any blockchain, cryptocurrency or otherwise. They represent a transfer of value from one network participant to another. In ARK, transactions can be of one of multiple types, specified in [AIP11](https://github.com/ARKEcosystem/AIPs/blob/master/AIPS/aip-11.md), which can affect the content and data structure of each transaction's payload.
+Transactions are the heart of any blockchain, cryptocurrency or otherwise. They represent a transfer of value from one network participant to another. In ARK, transactions can be of one of multiple types, specified in [AIP11](https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-11.md), which can affect the content and data structure of each transaction's payload.
 
 * **id**
 * **blockId** _the ID of the block in which this transaction is included_

--- a/docs/core/releases/release/2.0.md.blade.php
+++ b/docs/core/releases/release/2.0.md.blade.php
@@ -64,13 +64,13 @@ All SDKs have been updated to reflect the change to `v2`. The structure of each 
 
 | Language | Client | Crypto |
 | :--- | :--- | :--- |
-| Java | [java-client](https://github.com/ARKEcosystem/java-client) | [java-crypto](https://github.com/ARKEcosystem/java-crypto) |
-| .NET | [dotnet-client](https://github.com/ARKEcosystem/dotnet-client) | [dotnet-crypto](https://github.com/ARKEcosystem/dotnet-crypto) |
-| PHP | [php-client](https://github.com/ARKEcosystem/php-client) | [php-crypto](https://github.com/ARKEcosystem/php-crypto) |
-| Python | [python-client](https://github.com/ARKEcosystem/python-client) | [python-crypto](https://github.com/ARKEcosystem/python-client) |
-| Golang | [go-client](https://github.com/ARKEcosystem/go-client) | [go-crypto](https://github.com/ARKEcosystem/go-crypto) |
-| CPP | [cpp-client](https://github.com/ARKEcosystem/cpp-client) | [crypto-client](https://github.com/ARKEcosystem/cpp-crypto) |
-| Ruby | [ruby-client](https://github.com/ARKEcosystem/ruby-client) | [ruby-crypto](https://github.com/ARKEcosystem/ruby-crypto) |
-| Swift | [swift-client](https://github.com/ARKEcosystem/swift-client) | [swift-crypto](https://github.com/ARKEcosystem/swift-crypto) |
-| Rust | [rust-client](https://github.com/ARKEcosystem/rust-client) | [rust-crypto](https://github.com/ARKEcosystem/rust-crypto) |
-| Elixir | [elixir-client](https://github.com/ARKEcosystem/elixir-client) | [elixir-crypto](https://github.com/ARKEcosystem/elixir-crypto) |
+| Java | [java-client](https://github.com/ArkEcosystem/java-client) | [java-crypto](https://github.com/ArkEcosystem/java-crypto) |
+| .NET | [dotnet-client](https://github.com/ArkEcosystem/dotnet-client) | [dotnet-crypto](https://github.com/ArkEcosystem/dotnet-crypto) |
+| PHP | [php-client](https://github.com/ArkEcosystem/php-client) | [php-crypto](https://github.com/ArkEcosystem/php-crypto) |
+| Python | [python-client](https://github.com/ArkEcosystem/python-client) | [python-crypto](https://github.com/ArkEcosystem/python-client) |
+| Golang | [go-client](https://github.com/ArkEcosystem/go-client) | [go-crypto](https://github.com/ArkEcosystem/go-crypto) |
+| CPP | [cpp-client](https://github.com/ArkEcosystem/cpp-client) | [crypto-client](https://github.com/ArkEcosystem/cpp-crypto) |
+| Ruby | [ruby-client](https://github.com/ArkEcosystem/ruby-client) | [ruby-crypto](https://github.com/ArkEcosystem/ruby-crypto) |
+| Swift | [swift-client](https://github.com/ArkEcosystem/swift-client) | [swift-crypto](https://github.com/ArkEcosystem/swift-crypto) |
+| Rust | [rust-client](https://github.com/ArkEcosystem/rust-client) | [rust-crypto](https://github.com/ArkEcosystem/rust-crypto) |
+| Elixir | [elixir-client](https://github.com/ArkEcosystem/elixir-client) | [elixir-crypto](https://github.com/ArkEcosystem/elixir-crypto) |

--- a/docs/core/releases/release/2.1.md.blade.php
+++ b/docs/core/releases/release/2.1.md.blade.php
@@ -16,7 +16,7 @@ We recommend staying on the latest version of ARK; however, this upgrade does no
 
 ## Breaking Changes <a id="breaking-changes"></a>
 
-Plugins relying on the core-APIs may need to be refactored to TypeScript, and cannot rely on the same modules anymore. The [changelog](https://github.com/ARKEcosystem/core/blob/master/CHANGELOG.md) contains all changes and references to each commit.
+Plugins relying on the core-APIs may need to be refactored to TypeScript, and cannot rely on the same modules anymore. The [changelog](https://github.com/ArkEcosystem/core/blob/master/CHANGELOG.md) contains all changes and references to each commit.
 
 ## New Features <a id="upgrading"></a>
 

--- a/docs/core/releases/release/2.2.md.blade.php
+++ b/docs/core/releases/release/2.2.md.blade.php
@@ -4,7 +4,7 @@ title: Release Guides - v2.2
 
 # v2.2
 
-ARK `v2.2` is a minor update, backward compatible with `v2.1.X`. This update introduces a [Command-line interface](https://en.wikipedia.org/wiki/Command-line_interface), which providers node maintainers and delegates all the tools they need to manage their nodes. It is more convenient to use then the old [Core Commander](https://github.com/ARKEcosystem/core-commander) and easier to maintain for updates.
+ARK `v2.2` is a minor update, backward compatible with `v2.1.X`. This update introduces a [Command-line interface](https://en.wikipedia.org/wiki/Command-line_interface), which providers node maintainers and delegates all the tools they need to manage their nodes. It is more convenient to use then the old [Core Commander](https://github.com/ArkEcosystem/core-commander) and easier to maintain for updates.
 
 * **Upgrade time**: low - upgrading to `v2.2` does not break any APIs and can be performed incrementally in the network.
 * **Complexity**: low - the internal blockchain representation is not altered.

--- a/docs/core/releases/release/2.3.md.blade.php
+++ b/docs/core/releases/release/2.3.md.blade.php
@@ -4,7 +4,7 @@ title: Release Guides - v2.3
 
 # v2.3
 
-ARK `v2.3` is a minor update but not backward compatible with `v2.2.X`. This update introduces [AIP29](https://github.com/ARKEcosystem/AIPs/blob/master/AIPS/aip-29.md), an increased vendor field length, various performance improvements and more.
+ARK `v2.3` is a minor update but not backward compatible with `v2.2.X`. This update introduces [AIP29](https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-29.md), an increased vendor field length, various performance improvements and more.
 
 * **Upgrade time**: low - upgrading to `v2.3` only requires minimal configuration changes.
 * **Complexity**: medium - the `wallets` table has been removed from the database which can impact third-party applications.
@@ -84,4 +84,4 @@ From 2.3.0 onwards the `next` channel will serve as a combination of all of the 
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/release/2.4.md.blade.php
+++ b/docs/core/releases/release/2.4.md.blade.php
@@ -94,4 +94,4 @@ The fee statistic are no longer included in the response of the `node/configurat
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/release/2.5.md.blade.php
+++ b/docs/core/releases/release/2.5.md.blade.php
@@ -38,4 +38,4 @@ All v2 API endpoints now return `BigInt` values as `string` to avoid rounding is
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/release/2.6.md.blade.php
+++ b/docs/core/releases/release/2.6.md.blade.php
@@ -133,4 +133,4 @@ After restarting, your node will first execute migrations to get the database re
 
 ### Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/release/3.0.md.blade.php
+++ b/docs/core/releases/release/3.0.md.blade.php
@@ -26,4 +26,4 @@ For detailed step-by-step instructions on upgrading from **Core v2.7** to **Core
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/2.0.md.blade.php
+++ b/docs/core/releases/upgrade/2.0.md.blade.php
@@ -6,7 +6,7 @@ title: Upgrade Guides - Core v1.0 to v2.0
 
 > This is an archived guide. `v2.0.X` has been deprecated.
 
-Initially, you might have created your BridgeChain using [ARK Node](https://github.com/ARKEcosystem/ark-node), the official v1 implementation. Now that [ARK Core](https://github.com/arkecosystem/core) (v2) has reached a stable, production-ready release, you will want to upgrade your network.
+Initially, you might have created your BridgeChain using [ARK Node](https://github.com/ArkEcosystem/ark-node), the official v1 implementation. Now that [ARK Core](https://github.com/arkecosystem/core) (v2) has reached a stable, production-ready release, you will want to upgrade your network.
 
 Depending on the size of your BridgeChain network, upgrading to `ARK Core` may need more or less preparation. Upgrading is a breaking change, and all `v1` nodes will become incompatible with your new network. You should ensure that your users are aware of the upgrade, and node operators have time to adequately prepare for the migration, as they will need to update their tools and code bases.
 
@@ -27,8 +27,8 @@ Together with your node operators, it would be best if you decided on a cutoff b
 
 The new `v2` implementation is backward compatible with `v1`; thus we can deploy our new nodes without forcing a migration. Your BridgeChain configuration is defined by the following files, which are needed by `v2` as well.
 
-* [config.mainnet.json](https://github.com/ARKEcosystem/ark-node/blob/mainnet/config.mainnet.json)
-* [genesisBlock.json](https://github.com/ARKEcosystem/ark-node/blob/mainnet/genesisBlock.json)
+* [config.mainnet.json](https://github.com/ArkEcosystem/ark-node/blob/mainnet/config.mainnet.json)
+* [genesisBlock.json](https://github.com/ArkEcosystem/ark-node/blob/mainnet/genesisBlock.json)
 
 Clone [ARK Core](https://github.com/arkecosystem/core) so that we can configure our network. Make sure to verify that you have the latest tag.
 

--- a/docs/core/releases/upgrade/2.1.md.blade.php
+++ b/docs/core/releases/upgrade/2.1.md.blade.php
@@ -14,7 +14,7 @@ Upgrading, in general, is as simple as updating your installation through the co
 
 ## Notes
 
-It is recommended to start your relay and forger through the [Core Commander](https://github.com/ARKEcosystem/core-commander). If you wish to run them on your own, you should take a look at how commander executes them via `pm2`.
+It is recommended to start your relay and forger through the [Core Commander](https://github.com/ArkEcosystem/core-commander). If you wish to run them on your own, you should take a look at how commander executes them via `pm2`.
 
 After upgrading you should check whether your application still works as expected and no plugins are broken. See the following notes on which changes to consider when upgrading from one version to another.
 
@@ -22,7 +22,7 @@ After upgrading you should check whether your application still works as expecte
 
 ### Upgrade Script
 
-You can either run `bash <(curl -s https://raw.githubusercontent.com/ARKEcosystem/core/master/upgrade/2.1.0/normal.sh)` or run below commands manually.
+You can either run `bash <(curl -s https://raw.githubusercontent.com/ArkEcosystem/core/master/upgrade/2.1.0/normal.sh)` or run below commands manually.
 
 #### Relay Runners & Delegates
 
@@ -47,7 +47,7 @@ bash commander.sh
 
 #### Exchanges
 
-You can either run `bash <(curl -s https://raw.githubusercontent.com/ARKEcosystem/core/master/upgrade/2.1.0/exchange.sh)` or run below commands manually.
+You can either run `bash <(curl -s https://raw.githubusercontent.com/ArkEcosystem/core/master/upgrade/2.1.0/exchange.sh)` or run below commands manually.
 
 ```bash
 #!/usr/bin/env bash

--- a/docs/core/releases/upgrade/2.2.md.blade.php
+++ b/docs/core/releases/upgrade/2.2.md.blade.php
@@ -69,4 +69,4 @@ rm -rf ~/core-commander
 
 Due to 2.2 being distributed and managed in a completely different way than 2.1 there might be cases where unexpected issues show up.
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/2.3.md.blade.php
+++ b/docs/core/releases/upgrade/2.3.md.blade.php
@@ -129,4 +129,4 @@ From 2.3.0 onwards the `next` channel will serve as a combination of all of the 
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/2.4.md.blade.php
+++ b/docs/core/releases/upgrade/2.4.md.blade.php
@@ -192,4 +192,4 @@ The fee statistic are no longer included in the response of the `node/configurat
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/2.5.md.blade.php
+++ b/docs/core/releases/upgrade/2.5.md.blade.php
@@ -32,4 +32,4 @@ All v2 API endpoints now return `BigInt` values as `string` to avoid rounding is
 
 ## Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/2.6.md.blade.php
+++ b/docs/core/releases/upgrade/2.6.md.blade.php
@@ -133,4 +133,4 @@ After restarting, your node will first execute migrations to get the database re
 
 ### Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.

--- a/docs/core/releases/upgrade/3.0.md.blade.php
+++ b/docs/core/releases/upgrade/3.0.md.blade.php
@@ -130,7 +130,7 @@ Each run-mode (`core`, `relay`, and `forger`) now contains its own configuration
 
 ### Reporting Problems
 
-If you happen to experience any issues, please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
+If you happen to experience any issues, please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
 
 ## API Changes
 

--- a/docs/core/releases/upgrade/docker/3.0.md.blade.php
+++ b/docs/core/releases/upgrade/docker/3.0.md.blade.php
@@ -25,8 +25,8 @@ Upgrading from `v2.7` to `v3.0` is relatively straightforward if you follow the 
 ```shell
 mkdir ~/mainnet &&
 cd ~/mainnet &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/mainnet.env &&
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/mainnet.env &&
 curl -sOJ https://snapshots.ark.io/v3-migrations.sql
 ```
 
@@ -71,7 +71,7 @@ Each run-mode (`core`, `relay`, and `forger`) now contains its own configuration
 
 ### Reporting Problems
 
-If you happen to experience any issues, please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
+If you happen to experience any issues, please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
 
 ## API Changes
 

--- a/docs/exchanges/configuring-rate-limits.md.blade.php
+++ b/docs/exchanges/configuring-rate-limits.md.blade.php
@@ -42,7 +42,7 @@ Cache timeouts can be disabled, which is especially useful on resource-strained 
 
 ## Further Reference <a id="further-reference"></a>
 
-ARK Core uses the [hapi](https://hapijs.com/) framework for its API internals and more specifically [hapi-rate-limit](https://github.com/wraithgar/hapi-rate-limit). This rate-limiter can be configured by setting/altering [core-api](https://github.com/ARKEcosystem/core/tree/develop/packages/core-api/src/defaults.js#L48-L56).
+ARK Core uses the [hapi](https://hapijs.com/) framework for its API internals and more specifically [hapi-rate-limit](https://github.com/wraithgar/hapi-rate-limit). This rate-limiter can be configured by setting/altering [core-api](https://github.com/ArkEcosystem/core/tree/develop/packages/core-api/src/defaults.js#L48-L56).
 
 ```javascript
 rateLimit: {

--- a/docs/exchanges/node-installation/docker-installation.md.blade.php
+++ b/docs/exchanges/node-installation/docker-installation.md.blade.php
@@ -112,8 +112,8 @@ sudo usermod -aG docker ${USER}
 ```bash
 mkdir mainnet &&
 cd mainnet &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/mainnet.env
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/mainnet.env
 ```
 
 ### Running the Node

--- a/docs/exchanges/public-api-guide.md.blade.php
+++ b/docs/exchanges/public-api-guide.md.blade.php
@@ -47,7 +47,7 @@ Connection<Two> connection = new Connection(map);
 package main
 
 import (
-  ark "github.com/ARKEcosystem/go-client/client"
+  ark "github.com/ArkEcosystem/go-client/client"
   "net/url"
   )
 
@@ -57,8 +57,8 @@ func main() {
 ```
 
 ```python
-from client import ARKClient
-client = ARKClient('http://127.0.0.1:4003/api')
+from client import ArkClient
+client = ArkClient('http://127.0.0.1:4003/api')
 ```
 
 ## Check Wallet Balance

--- a/docs/exchanges/upgrade/baremetal.md.blade.php
+++ b/docs/exchanges/upgrade/baremetal.md.blade.php
@@ -170,7 +170,7 @@ Each run-mode (`core`, `relay`, and `forger`) now contains its own configuration
 
 ### Reporting Problems
 
-If you happen to experience any issues, please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
+If you happen to experience any issues, please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
 
 ## API Changes
 

--- a/docs/exchanges/upgrade/docker.md.blade.php
+++ b/docs/exchanges/upgrade/docker.md.blade.php
@@ -25,8 +25,8 @@ Upgrading from `v2.7` to `v3.0` is relatively straightforward if you follow the 
 ```shell
 mkdir ~/mainnet &&
 cd ~/mainnet &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
-curl -sOJ https://raw.githubusercontent.com/ARKEcosystem/core/master/docker/production/mainnet/mainnet.env &&
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/docker-compose.yml &&
+curl -sOJ https://raw.githubusercontent.com/ArkEcosystem/core/master/docker/production/mainnet/mainnet.env &&
 curl -sOJ https://snapshots.ark.io/v3-migrations.sql
 ```
 
@@ -71,7 +71,7 @@ Each run-mode (`core`, `relay`, and `forger`) now contains its own configuration
 
 ### Reporting Problems
 
-If you happen to experience any issues, please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
+If you happen to experience any issues, please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it, and info about your environment.
 
 ## API Changes
 

--- a/docs/exchanges/upgrade/json-rpc.md.blade.php
+++ b/docs/exchanges/upgrade/json-rpc.md.blade.php
@@ -16,7 +16,7 @@ exchange-json-rpc update --force --restart
 
 ### Reporting Problems
 
-If you happen to experience any issues please [open an issue](https://github.com/ARKEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
+If you happen to experience any issues please [open an issue](https://github.com/ArkEcosystem/core/issues/new?template=Bug_report.md) with a detailed description of the problem, steps to reproduce it and info about your environment.
 
 ## Related ARK Core API changes
 

--- a/docs/sdk/c++/client/intro.md.blade.php
+++ b/docs/sdk/c++/client/intro.md.blade.php
@@ -6,7 +6,7 @@ title: Getting Started
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/cpp-client).
+1. Fork the [package](https://github.com/ArkEcosystem/cpp-client).
 2. Clone the newly forked repository.
 
 ```bash

--- a/docs/sdk/c++/crypto/intro.md.blade.php
+++ b/docs/sdk/c++/crypto/intro.md.blade.php
@@ -6,7 +6,7 @@ title: Getting Started
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/cpp-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/cpp-crypto).
 2. Clone the newly forked repository.
 
 ```bash

--- a/docs/sdk/c++/installation.md.blade.php
+++ b/docs/sdk/c++/installation.md.blade.php
@@ -68,7 +68,7 @@ cmake --build .
 
 Download and install the Arduino IDE (&gt;=1.8.5) from [arduino.cc](https://www.arduino.cc/en/Main/Software)
 
-Using the Arduino IDEs built-in Library Manager, install the ARK-Cpp-Crypto library. Be sure to install the "-arduino" version of Cpp-Crypto.
+Using the Arduino IDEs built-in Library Manager, install the Ark-Cpp-Crypto library. Be sure to install the "-arduino" version of Cpp-Crypto.
 
 #### Dependencies
 

--- a/docs/sdk/dotnet/client/examples.md.blade.php
+++ b/docs/sdk/dotnet/client/examples.md.blade.php
@@ -11,8 +11,8 @@ WARNING! This package is deprecated and is no longer maintained and supported.
 ## Initialization
 
 ```csharp
-using ARKEcosystem.Client;
-using ARKEcosystem.Client.API;
+using ArkEcosystem.Client;
+using ArkEcosystem.Client.API;
 
 static void Main(string[] args)
 {

--- a/docs/sdk/dotnet/client/getting-started.md.blade.php
+++ b/docs/sdk/dotnet/client/getting-started.md.blade.php
@@ -25,13 +25,13 @@ For further information on how to install .NET on your operating system :
 ### Package Manager
 
 ```bash
-Install-Package ARKEcosystem.Client -Version 0.2.1
+Install-Package ArkEcosystem.Client -Version 0.2.1
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ARKEcosystem.Client --version 0.2.1
+dotnet add package ArkEcosystem.Client --version 0.2.1
 ```
 
 ### PackageReference
@@ -45,12 +45,12 @@ For projects that support PackageReference, copy this XML node into the project 
 ### Paket CLI
 
 ```bash
-paket add ARKEcosystem.Client --version 0.2.1
+paket add ArkEcosystem.Client --version 0.2.1
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/dotnet-client).
+1. Fork the [package](https://github.com/ArkEcosystem/dotnet-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/dotnet/client/intro.md.blade.php
+++ b/docs/sdk/dotnet/client/intro.md.blade.php
@@ -15,13 +15,13 @@ WARNING! This package is deprecated and is no longer maintained and supported.
 ### Install Package
 
 ```bash
-Install-Package ARKEcosystem.Client -Version 0.2.1
+Install-Package ArkEcosystem.Client -Version 0.2.1
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ARKEcosystem.Client --version 0.2.1
+dotnet add package ArkEcosystem.Client --version 0.2.1
 ```
 
 ### PackageReference
@@ -35,12 +35,12 @@ For projects that support PackageReference, copy this XML node into the project 
 ### Paket CLI
 
 ```bash
-paket add ARKEcosystem.Client --version 0.2.1
+paket add ArkEcosystem.Client --version 0.2.1
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/dotnet-client).
+1. Fork the [package](https://github.com/ArkEcosystem/dotnet-client).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/dotnet/crypto/examples.md.blade.php
+++ b/docs/sdk/dotnet/crypto/examples.md.blade.php
@@ -11,7 +11,7 @@ WARNING! This package is deprecated and is no longer maintained and supported.
 ## Initialization
 
 ```csharp
-using ARKEcosystem.Crypto;
+using ArkEcosystem.Crypto;
 ```
 
 ## Transactions

--- a/docs/sdk/dotnet/crypto/getting-started.md.blade.php
+++ b/docs/sdk/dotnet/crypto/getting-started.md.blade.php
@@ -25,13 +25,13 @@ For further information on how to install .NET on your operating system :
 ### Package Manager
 
 ```bash
-Install-Package ARKEcosystem.Crypto -Version 0.2.1
+Install-Package ArkEcosystem.Crypto -Version 0.2.1
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ARKEcosystem.Crypto --version 0.2.1
+dotnet add package ArkEcosystem.Crypto --version 0.2.1
 ```
 
 ### PackageReference
@@ -45,12 +45,12 @@ For projects that support PackageReference, copy this XML node into the project 
 ### Paket CLI
 
 ```bash
-paket add ARKEcosystem.Crypto --version 0.2.1
+paket add ArkEcosystem.Crypto --version 0.2.1
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/dotnet-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/dotnet-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/dotnet/crypto/intro.md.blade.php
+++ b/docs/sdk/dotnet/crypto/intro.md.blade.php
@@ -15,13 +15,13 @@ WARNING! This package is deprecated and is no longer maintained and supported.
 ### Install Package
 
 ```bash
-Install-Package ARKEcosystem.Crypto -Version 0.2.1
+Install-Package ArkEcosystem.Crypto -Version 0.2.1
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ARKEcosystem.Crypto --version 0.2.1
+dotnet add package ArkEcosystem.Crypto --version 0.2.1
 ```
 
 ### PackageReference
@@ -35,12 +35,12 @@ For projects that support PackageReference, copy this XML node into the project 
 ### Paket CLI
 
 ```bash
-paket add ARKEcosystem.Crypto --version 0.2.1
+paket add ArkEcosystem.Crypto --version 0.2.1
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/dotnet-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/dotnet-crypto).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/elixir/client/examples.md.blade.php
+++ b/docs/sdk/elixir/client/examples.md.blade.php
@@ -7,7 +7,7 @@ title: Examples
 ## Initialization
 
 ```elixir
-client = ARKEcosystem.Client.new(%{
+client = ArkEcosystem.Client.new(%{
     host: "http://my.node.ip:myport/api",
     nethash: "validNethash",
     version: "1.0.0"
@@ -23,7 +23,7 @@ This service API grants access to the [blocks resource](https://github.com/ArkEc
 ### List All Blocks
 
 ```elixir
-blocks = ARKEcosystem.Client.API.Blocks.list(client)
+blocks = ArkEcosystem.Client.API.Blocks.list(client)
 
 IO.inspect blocks
 
@@ -33,7 +33,7 @@ IO.inspect blocks
 ### Retrieve a Block
 
 ```elixir
-block = ARKEcosystem.Client.API.Blocks.show(client, "validBlockId")
+block = ArkEcosystem.Client.API.Blocks.show(client, "validBlockId")
 
 IO.inspect block
 
@@ -43,7 +43,7 @@ IO.inspect block
 ### List All Transactions of a Block
 
 ```elixir
-blockTransactions = ARKEcosystem.Client.API.Blocks.transactions(client, "validBlockId")
+blockTransactions = ArkEcosystem.Client.API.Blocks.transactions(client, "validBlockId")
 
 IO.inspect blockTransactions
 
@@ -53,7 +53,7 @@ IO.inspect blockTransactions
 ### Search All Blocks
 
 ```elixir
-searchedBlock = ARKEcosystem.Client.API.Blocks.search(client, %{q: "searchQuery"})
+searchedBlock = ArkEcosystem.Client.API.Blocks.search(client, %{q: "searchQuery"})
 
 IO.inspect searchedBlock
 
@@ -71,7 +71,7 @@ A delegate is a regular wallet that has broadcast a registration transaction, ac
 ### List All Delegates
 
 ```elixir
-delegates = ARKEcosystem.Client.API.Delegates.list(client)
+delegates = ArkEcosystem.Client.API.Delegates.list(client)
 
 IO.inspect delegates
 
@@ -81,7 +81,7 @@ IO.inspect delegates
 ### Retrieve a Delegate
 
 ```elixir
-delegate = ARKEcosystem.Client.API.Delegates.show(client, "validDelegateId")
+delegate = ArkEcosystem.Client.API.Delegates.show(client, "validDelegateId")
 
 IO.inspect delegate
 
@@ -91,7 +91,7 @@ IO.inspect delegate
 ### List All Blocks of a Delegate
 
 ```elixir
-delegateBlocks = ARKEcosystem.Client.API.Delegates.blocks(client, "validDelegateId")
+delegateBlocks = ArkEcosystem.Client.API.Delegates.blocks(client, "validDelegateId")
 
 IO.inspect delegateBlocks
 
@@ -101,7 +101,7 @@ IO.inspect delegateBlocks
 ### List All Voters of a Delegate
 
 ```elixir
-delegateVoters = ARKEcosystem.Client.API.Delegates.voters(client, "validDelegateId")
+delegateVoters = ArkEcosystem.Client.API.Delegates.voters(client, "validDelegateId")
 
 IO.inspect delegateVoters
 
@@ -115,7 +115,7 @@ The ARK network consists of different anonymous nodes (servers), maintaining the
 ### Retrieve the Configuration
 
 ```elixir
-nodeConfiguration = ARKEcosystem.Client.API.Node.configuration(client)
+nodeConfiguration = ArkEcosystem.Client.API.Node.configuration(client)
 
 IO.inspect nodeConfiguration
 
@@ -125,7 +125,7 @@ IO.inspect nodeConfiguration
 ### Retrieve the Status
 
 ```elixir
-nodeStatus = ARKEcosystem.Client.API.Node.status(client)
+nodeStatus = ArkEcosystem.Client.API.Node.status(client)
 
 IO.inspect nodeStatus
 
@@ -135,7 +135,7 @@ IO.inspect nodeStatus
 ### Retrieve the Syncing Status
 
 ```elixir
-nodeSyncingStatus = ARKEcosystem.Client.API.Node.syncing(client)
+nodeSyncingStatus = ArkEcosystem.Client.API.Node.syncing(client)
 
 IO.inspect nodeSyncingStatus
 
@@ -151,7 +151,7 @@ Each node is connected to a set of peers, which are Relay or Delegate Nodes as w
 ### List All Peers
 
 ```elixir
-peers = ARKEcosystem.Client.API.Peers.list(client)
+peers = ArkEcosystem.Client.API.Peers.list(client)
 
 IO.inspect peers
 
@@ -161,7 +161,7 @@ IO.inspect peers
 ### Retrieve a Peer
 
 ```elixir
-peer = ARKEcosystem.Client.API.Peers.show(client, "validIpAddress")
+peer = ArkEcosystem.Client.API.Peers.show(client, "validIpAddress")
 
 IO.inspect peer
 
@@ -177,7 +177,7 @@ The heart of any blockchain is formed by its transactions; state-altering payloa
 ### Create a Transaction
 
 ```elixir
-transaction = ARKEcosystem.Client.API.Transactions.create(client, %{id: "dummyCreatedId"})
+transaction = ArkEcosystem.Client.API.Transactions.create(client, %{id: "dummyCreatedId"})
 
 IO.inspect transaction
 
@@ -187,7 +187,7 @@ IO.inspect transaction
 ### Retrieve a Transaction
 
 ```elixir
-transaction = ARKEcosystem.Client.API.Transactions.show(client, "validTransactionId")
+transaction = ArkEcosystem.Client.API.Transactions.show(client, "validTransactionId")
 
 IO.inspect transaction
 
@@ -197,7 +197,7 @@ IO.inspect transaction
 ### List All Transactions
 
 ```elixir
-transactions = ARKEcosystem.Client.API.Transactions.list(client)
+transactions = ArkEcosystem.Client.API.Transactions.list(client)
 
 IO.inspect transactions
 
@@ -207,7 +207,7 @@ IO.inspect transactions
 ### List All Unconfirmed Transactions
 
 ```elixir
-unconfirmedTransactions = ARKEcosystem.Client.API.Transactions.list_unconfirmed(client)
+unconfirmedTransactions = ArkEcosystem.Client.API.Transactions.list_unconfirmed(client)
 
 IO.inspect unconfirmedTransactions
 
@@ -217,7 +217,7 @@ IO.inspect unconfirmedTransactions
 ### Get Unconfirmed Transaction
 
 ```elixir
-unconfirmedTransaction = ARKEcosystem.Client.API.Transactions.list_unconfirmed(client, "validTransactionId")
+unconfirmedTransaction = ArkEcosystem.Client.API.Transactions.list_unconfirmed(client, "validTransactionId")
 
 IO.inspect unconfirmedTransaction
 
@@ -227,7 +227,7 @@ IO.inspect unconfirmedTransaction
 ### Search Transactions
 
 ```elixir
-transactions = ARKEcosystem.Client.API.Transactions.search(client, %{q: "searchQuery"})
+transactions = ArkEcosystem.Client.API.Transactions.search(client, %{q: "searchQuery"})
 
 IO.inspect transactions
 
@@ -237,7 +237,7 @@ IO.inspect transactions
 ### List Transaction Types
 
 ```elixir
-transactionTypes = ARKEcosystem.Client.API.Transactions.types(client)
+transactionTypes = ArkEcosystem.Client.API.Transactions.types(client)
 
 IO.inspect transactionTypes
 
@@ -251,7 +251,7 @@ A [vote](https://github.com/ArkEcosystem/gitbooks-sdk/tree/fcb399a02301c4ed91f0d
 ### List All Votes
 
 ```elixir
-votes = ARKEcosystem.Client.API.Votes.list(client)
+votes = ArkEcosystem.Client.API.Votes.list(client)
 
 IO.inspect votes
 
@@ -261,7 +261,7 @@ IO.inspect votes
 ### Retrieve a Vote
 
 ```elixir
-vote = ARKEcosystem.Client.API.Transactions.types(client, "validVoteId")
+vote = ArkEcosystem.Client.API.Transactions.types(client, "validVoteId")
 
 IO.inspect vote
 
@@ -279,7 +279,7 @@ The [wallet resource](https://github.com/ArkEcosystem/gitbooks-sdk/tree/fcb399a0
 ### Retrieve All Wallets
 
 ```elixir
-wallets = ARKEcosystem.Client.API.Wallets.list(client)
+wallets = ArkEcosystem.Client.API.Wallets.list(client)
 
 IO.inspect wallets
 
@@ -289,7 +289,7 @@ IO.inspect wallets
 ### Retrieve a Wallet
 
 ```elixir
-wallet = ARKEcosystem.Client.API.Wallets.show(client, "validWalletId")
+wallet = ArkEcosystem.Client.API.Wallets.show(client, "validWalletId")
 
 IO.inspect wallet
 
@@ -299,7 +299,7 @@ IO.inspect wallet
 ### List All Transactions of a Wallet
 
 ```elixir
-walletTransactions = ARKEcosystem.Client.API.Wallets.transactions(client, "validWalletId")
+walletTransactions = ArkEcosystem.Client.API.Wallets.transactions(client, "validWalletId")
 
 IO.inspect walletTransactions
 
@@ -309,7 +309,7 @@ IO.inspect walletTransactions
 ### List All Received Transactions of a Wallet
 
 ```elixir
-walletReceivedTransactions = ARKEcosystem.Client.API.Wallets.received_transactions(client, "validWalletId")
+walletReceivedTransactions = ArkEcosystem.Client.API.Wallets.received_transactions(client, "validWalletId")
 
 IO.inspect walletReceivedTransactions
 
@@ -319,7 +319,7 @@ IO.inspect walletReceivedTransactions
 ### List All Sent Transactions of a Wallet
 
 ```elixir
-walletSentTransactions = ARKEcosystem.Client.API.Wallets.sent_transactions(client, "validWalletId")
+walletSentTransactions = ArkEcosystem.Client.API.Wallets.sent_transactions(client, "validWalletId")
 
 IO.inspect walletReceivedTransactions
 
@@ -329,7 +329,7 @@ IO.inspect walletReceivedTransactions
 ### List All Votes of a Wallet
 
 ```elixir
-walletVotes = ARKEcosystem.Client.API.Wallets.votes(client, "validWalletId")
+walletVotes = ArkEcosystem.Client.API.Wallets.votes(client, "validWalletId")
 
 IO.inspect walletVotes
 
@@ -339,7 +339,7 @@ IO.inspect walletVotes
 ### List All Top Wallets
 
 ```elixir
-topWallets = ARKEcosystem.Client.API.Wallets.top(client)
+topWallets = ArkEcosystem.Client.API.Wallets.top(client)
 
 IO.inspect topWallets
 
@@ -349,7 +349,7 @@ IO.inspect topWallets
 ### Search All Wallets
 
 ```elixir
-wallets = ARKEcosystem.Client.API.Wallets.search(client, %{q: "searchQuery"})
+wallets = ArkEcosystem.Client.API.Wallets.search(client, %{q: "searchQuery"})
 
 IO.inspect wallets
 

--- a/docs/sdk/elixir/client/getting-started.md.blade.php
+++ b/docs/sdk/elixir/client/getting-started.md.blade.php
@@ -38,7 +38,7 @@ mix deps.get
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/elixir-client).
+1. Fork the [package](https://github.com/ArkEcosystem/elixir-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/elixir/client/intro.md.blade.php
+++ b/docs/sdk/elixir/client/intro.md.blade.php
@@ -22,7 +22,7 @@ mix deps.get
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/elixir-client).
+1. Fork the [package](https://github.com/ArkEcosystem/elixir-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/elixir/crypto/examples.md.blade.php
+++ b/docs/sdk/elixir/crypto/examples.md.blade.php
@@ -7,8 +7,8 @@ title: Examples
 ## Initialization
 
 ```elixir
-alias ARKEcosystem.Crypto.Transactions.Transaction
-alias ARKEcosystem.Crypto.Transactions.Builder
+alias ArkEcosystem.Crypto.Transactions.Transaction
+alias ArkEcosystem.Crypto.Transactions.Builder
 ```
 
 ## Transactions
@@ -20,8 +20,8 @@ A transaction is an object specifying the transfer of funds from the sender's wa
 The crypto SDK can sign a transaction using your private key or passphrase (from which the private key is generated). Ensure you are familiar with [digital signatures](https://en.wikipedia.org/wiki/Digital_signature) before using the crypto SDKs.
 
 ```elixir
-alias ARKEcosystem.Crypto.Transactions.Transaction
-alias ARKEcosystem.Crypto.Transactions.Builder
+alias ArkEcosystem.Crypto.Transactions.Transaction
+alias ArkEcosystem.Crypto.Transactions.Builder
 
 transaction = Builder.build_transfer(
     "validAddress",
@@ -39,7 +39,7 @@ IO.puts Transaction.sign_transaction(transaction, passphrase, secondPassphrase)
 > Serialization of a transaction object ensures it is compact and properly formatted to be incorporated in the ARK blockchain. If you are using the crypto SDK in combination with the public API SDK, you should not need to serialize manually.
 
 ```elixir
-alias ARKEcosystem.Crypto.Transactions.Serializer
+alias ArkEcosystem.Crypto.Transactions.Serializer
 
 serialized = Serializer.serialize(transaction, %{underscore: true})
 
@@ -51,7 +51,7 @@ serialized = Serializer.serialize(transaction, %{underscore: true})
 > A serialized transaction may be deserialized for inspection purposes. The public API does not return serialized transactions, so you should only need to deserialize in exceptional circumstances.
 
 ```elixir
-alias ARKEcosystem.Crypto.Transactions.Deserializer
+alias ArkEcosystem.Crypto.Transactions.Deserializer
 
 transaction = Deserializer.deserialize(serialized_transaction)
 
@@ -67,7 +67,7 @@ The crypto SDK not only supports transactions but can also work with other arbit
 > Signing a string works much like signing a transaction: in most implementations, the message is hashed, and the resulting hash is signed using the `private key` or `passphrase`.
 
 ```elixir
-alias ARKEcosystem.Crypto.Utils.Message
+alias ArkEcosystem.Crypto.Utils.Message
 
 message = Message.sign("Hello World", "passphrase")
 
@@ -79,7 +79,7 @@ message = Message.sign("Hello World", "passphrase")
 > A message's signature can easily be verified by hash, without the private key that signed the message, by using the `verify` method.
 
 ```elixir
-alias ARKEcosystem.Crypto.Utils.Message
+alias ArkEcosystem.Crypto.Utils.Message
 
 message = Message.sign("Hello World", "passphrase")
 
@@ -95,7 +95,7 @@ IO.puts Message.verify(message.message, message.signature, message.publicKey)
 ### Derive the Address from a Passphrase
 
 ```elixir
-ARKEcosystem.Crypto.Identities.Address.from_passphrase('this is a top secret passphrase')
+ArkEcosystem.Crypto.Identities.Address.from_passphrase('this is a top secret passphrase')
 
 >>> string
 ```
@@ -103,7 +103,7 @@ ARKEcosystem.Crypto.Identities.Address.from_passphrase('this is a top secret pas
 ### Derive the Address from a Public Key
 
 ```elixir
-ARKEcosystem.Crypto.Identities.Address.from_public_key('validPublicKey')
+ArkEcosystem.Crypto.Identities.Address.from_public_key('validPublicKey')
 
 >>> string
 ```
@@ -111,7 +111,7 @@ ARKEcosystem.Crypto.Identities.Address.from_public_key('validPublicKey')
 ### Derive the Address from a Private Key
 
 ```elixir
-ARKEcosystem.Crypto.Identities.Address.from_private_key('validPrivateKey')
+ArkEcosystem.Crypto.Identities.Address.from_private_key('validPrivateKey')
 
 >>> string
 ```
@@ -119,7 +119,7 @@ ARKEcosystem.Crypto.Identities.Address.from_private_key('validPrivateKey')
 ### Validate an Address
 
 ```elixir
-ARKEcosystem.Crypto.Identities.Address.validate('validAddress')
+ArkEcosystem.Crypto.Identities.Address.validate('validAddress')
 
 >>> bool
 ```
@@ -131,7 +131,7 @@ ARKEcosystem.Crypto.Identities.Address.validate('validAddress')
 ### Derive the Private Key from a Passphrase
 
 ```elixir
-ARKEcosystem.Crypto.Identities.PrivateKey.from_passphrase('this is a top secret passphrase')
+ArkEcosystem.Crypto.Identities.PrivateKey.from_passphrase('this is a top secret passphrase')
 
 >>> EcPrivateKey
 ```
@@ -139,7 +139,7 @@ ARKEcosystem.Crypto.Identities.PrivateKey.from_passphrase('this is a top secret 
 ### Derive the Private Key Instance Object from a Hexadecimal Encoded String
 
 ```elixir
-ARKEcosystem.Crypto.Identities.PrivateKey.from_hex('validHexString')
+ArkEcosystem.Crypto.Identities.PrivateKey.from_hex('validHexString')
 
 >>> EcPrivateKey
 ```
@@ -157,7 +157,7 @@ This function has not been implemented in this client library.
 ### Derive the Public Key from a Passphrase
 
 ```elixir
-ARKEcosystem.Crypto.Identities.PublicKey.from_passphrase('this is a top secret passphrase')
+ArkEcosystem.Crypto.Identities.PublicKey.from_passphrase('this is a top secret passphrase')
 
 >>> EcPublicKey
 ```
@@ -165,7 +165,7 @@ ARKEcosystem.Crypto.Identities.PublicKey.from_passphrase('this is a top secret p
 ### Derive the Public Key Instance Object from a Hexadecimal Encoded String
 
 ```elixir
-ARKEcosystem.Crypto.Identities.PublicKey.from_hex('validHexString')
+ArkEcosystem.Crypto.Identities.PublicKey.from_hex('validHexString')
 
 >>> EcPublicKey
 ```
@@ -183,7 +183,7 @@ This function has not been implemented in this client library.
 ### Derive the WIF from a Passphrase
 
 ```elixir
-ARKEcosystem.Crypto.Identities.WIF.from_passphrase('this is a top secret passphrase')
+ArkEcosystem.Crypto.Identities.WIF.from_passphrase('this is a top secret passphrase')
 
 >>> string
 ```

--- a/docs/sdk/elixir/crypto/getting-started.md.blade.php
+++ b/docs/sdk/elixir/crypto/getting-started.md.blade.php
@@ -38,7 +38,7 @@ mix deps.get
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/elixir-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/elixir-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/elixir/crypto/intro.md.blade.php
+++ b/docs/sdk/elixir/crypto/intro.md.blade.php
@@ -22,7 +22,7 @@ mix deps.get
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/elixir-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/elixir-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/frameworks/laravel.md.blade.php
+++ b/docs/sdk/frameworks/laravel.md.blade.php
@@ -17,7 +17,7 @@ composer require arkecosystem/laravel
 ARK Laravel requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-php artisan vendor:publish --provider="ARKEcosystem\ARK\ARKServiceProvider"
+php artisan vendor:publish --provider="ArkEcosystem\Ark\ArkServiceProvider"
 ```
 
 This will create a `config/ark.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.
@@ -32,15 +32,15 @@ This option `connections` is where each of the connections is set up for your ap
 
 ## Usage
 
-### ARKManager
+### ArkManager
 
-This is the class of most interest. It is bound to the ioc container as `ark` and can be accessed using the `Facades\ARK` facade. This class implements the ManagerInterface by extending AbstractManager. The interface and abstract class are both part of [Graham Campbell's](https://github.com/GrahamCampbell) [Laravel Manager](https://github.com/GrahamCampbell/Laravel-Manager) package, so you may want to go and check out the docs for how to use the manager class over at that repository. Note that the connection class returned will always be an instance of `ARK\ARK`.
+This is the class of most interest. It is bound to the ioc container as `ark` and can be accessed using the `Facades\Ark` facade. This class implements the ManagerInterface by extending AbstractManager. The interface and abstract class are both part of [Graham Campbell's](https://github.com/GrahamCampbell) [Laravel Manager](https://github.com/GrahamCampbell/Laravel-Manager) package, so you may want to go and check out the docs for how to use the manager class over at that repository. Note that the connection class returned will always be an instance of `Ark\Ark`.
 
-### Facades\ARK
+### Facades\Ark
 
-This facade will dynamically pass static method calls to the `ark` object in the ioc container which by default is the `ARKManager` class.
+This facade will dynamically pass static method calls to the `ark` object in the ioc container which by default is the `ArkManager` class.
 
-### ARKServiceProvider
+### ArkServiceProvider
 
 _This class contains no public methods of interest, it should be added to the providers array in `config/app.php` as it sets up ioc bindings._
 
@@ -50,43 +50,43 @@ Here you can see an example of just how simple this package is to use. Out of th
 
 ```php
 // You can alias this in config/app.php.
-use ARKEcosystem\ARK\Facades\ARK;
+use ArkEcosystem\Ark\Facades\Ark;
 
-ARK::api('Wallets')->wallets();
+Ark::api('Wallets')->wallets();
 // We're done here - how easy was that, it just works!
 ```
 
-The ARK manager will behave like it is an `ARKEcosystem\ARK\Client`. If you want to call specific connections, you can do that with the connection method:
+The ARK manager will behave like it is an `ArkEcosystem\Ark\Client`. If you want to call specific connections, you can do that with the connection method:
 
 ```php
-use ARKEcosystem\ARK\Facades\ARK;
+use ArkEcosystem\Ark\Facades\Ark;
 
 // Writing this…
-ARK::connection('main')->api('Wallets')->all();
+Ark::connection('main')->api('Wallets')->all();
 
 // …is identical to writing this
-ARK::api('Wallets')->all();
+Ark::api('Wallets')->all();
 
 // and is also identical to writing this.
-ARK::connection()->api('Wallets')->all();
+Ark::connection()->api('Wallets')->all();
 
 // This is because the main connection is configured to be the default.
-ARK::getDefaultConnection(); // This will return main.
+Ark::getDefaultConnection(); // This will return main.
 
 // We can change the default connection.
-ARK::setDefaultConnection('alternative'); // The default is now alternative.
+Ark::setDefaultConnection('alternative'); // The default is now alternative.
 ```
 
 If you prefer to use dependency injection over facades like me, then you can inject the manager:
 
 ```php
-use ARKEcosystem\ARK\ARKManager;
+use ArkEcosystem\Ark\ArkManager;
 
 class Foo
 {
     protected $ark;
 
-    public function __construct(ARKManager $ark)
+    public function __construct(ArkManager $ark)
     {
         $this->ark = $ark;
     }

--- a/docs/sdk/frameworks/symfony.md.blade.php
+++ b/docs/sdk/frameworks/symfony.md.blade.php
@@ -18,7 +18,7 @@ Go to `config/packages/ark.yml` and fill out your configuration similar to this.
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     // ...
-    ARKEcosystem\ARKBundle\ARKBundle::class => ['all' => true],
+    ArkEcosystem\ArkBundle\ArkBundle::class => ['all' => true],
 ];
 ```
 

--- a/docs/sdk/go/client/examples.md.blade.php
+++ b/docs/sdk/go/client/examples.md.blade.php
@@ -12,7 +12,7 @@ package main
 import (
     "net/url"
 
-    ark "github.com/ARKEcosystem/go-client/client"
+    ark "github.com/ArkEcosystem/go-client/client"
 )
 
 func main() {

--- a/docs/sdk/go/client/getting-started.md.blade.php
+++ b/docs/sdk/go/client/getting-started.md.blade.php
@@ -15,12 +15,12 @@ For further information on how to install Go on your operating system, follow [t
 ### Install package with `get`
 
 ```bash
-go get github.com/ARKEcosystem/go-client/client
+go get github.com/ArkEcosystem/go-client/client
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/go-client)
+1. Fork the [package](https://github.com/ArkEcosystem/go-client)
 
 2. Clone your forked repository.
 

--- a/docs/sdk/go/client/intro.md.blade.php
+++ b/docs/sdk/go/client/intro.md.blade.php
@@ -7,12 +7,12 @@ title: Getting Started
 ## Install package with `get`
 
 ```bash
-go get github.com/ARKEcosystem/go-client/client
+go get github.com/ArkEcosystem/go-client/client
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/go-client)
+1. Fork the [package](https://github.com/ArkEcosystem/go-client)
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/go/crypto/examples.md.blade.php
+++ b/docs/sdk/go/crypto/examples.md.blade.php
@@ -10,7 +10,7 @@ title: Examples
 package main
 
 import (
-    crypto "github.com/ARKEcosystem/go-crypto/crypto"
+    crypto "github.com/ArkEcosystem/go-crypto/crypto"
 )
 ```
 

--- a/docs/sdk/go/crypto/getting-started.md.blade.php
+++ b/docs/sdk/go/crypto/getting-started.md.blade.php
@@ -15,12 +15,12 @@ For further information on how to install Go on your operating system, follow [t
 ### Install package with `get`
 
 ```bash
-go get github.com/ARKEcosystem/go-crypto/crypto
+go get github.com/ArkEcosystem/go-crypto/crypto
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/go-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/go-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/go/crypto/intro.md.blade.php
+++ b/docs/sdk/go/crypto/intro.md.blade.php
@@ -9,12 +9,12 @@ title: Getting Started
 > Get downloads the packages named by the import paths, along with their dependencies. It then installs the named packages, like 'go install'.
 
 ```bash
-go get github.com/ARKEcosystem/go-crypto/crypto
+go get github.com/ArkEcosystem/go-crypto/crypto
 ```
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/go-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/go-crypto).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/guidelines/client.md.blade.php
+++ b/docs/sdk/guidelines/client.md.blade.php
@@ -64,11 +64,11 @@ There are already a few implementations of cryptography packages available, so t
 
 ### Object Oriented Programming
 
-* [https://github.com/ARKEcosystem/php-client](https://github.com/ARKEcosystem/php-client)
-* [https://github.com/ARKEcosystem/python-client](https://github.com/ARKEcosystem/python-client)
-* [https://github.com/ARKEcosystem/ruby-client](https://github.com/ARKEcosystem/ruby-client)
+* [https://github.com/ArkEcosystem/php-client](https://github.com/ArkEcosystem/php-client)
+* [https://github.com/ArkEcosystem/python-client](https://github.com/ArkEcosystem/python-client)
+* [https://github.com/ArkEcosystem/ruby-client](https://github.com/ArkEcosystem/ruby-client)
 
 ### Functional Programming
 
-* [https://github.com/ARKEcosystem/elixir-client](https://github.com/ARKEcosystem/elixir-client)
-* [https://github.com/ARKEcosystem/go-client](https://github.com/ARKEcosystem/go-client)
+* [https://github.com/ArkEcosystem/elixir-client](https://github.com/ArkEcosystem/elixir-client)
+* [https://github.com/ArkEcosystem/go-client](https://github.com/ArkEcosystem/go-client)

--- a/docs/sdk/guidelines/crypto.md.blade.php
+++ b/docs/sdk/guidelines/crypto.md.blade.php
@@ -96,7 +96,7 @@ Following these guidelines is required to provide a streamlined experience acros
 
 The structure outlined here should be followed as closely as possible. If you work with an **Object Oriented Programming Language** you should be able to implement this structure as is, small adjustments might be required for languages like Go as nested packages can get hacky.
 
-You can check [https://github.com/ARKEcosystem/php-crypto](https://github.com/ARKEcosystem/php-crypto) for an example of how this structure looks like when implemented and how it is reflected in the structure of tests.
+You can check [https://github.com/ArkEcosystem/php-crypto](https://github.com/ArkEcosystem/php-crypto) for an example of how this structure looks like when implemented and how it is reflected in the structure of tests.
 
 ```text
 [src | lib | crypto]
@@ -164,11 +164,11 @@ There are already a few implementations of cryptography packages available, so t
 
 ### Object Oriented Programming
 
-* [https://github.com/ARKEcosystem/php-crypto](https://github.com/ARKEcosystem/php-crypto)
-* [https://github.com/ARKEcosystem/python-crypto](https://github.com/ARKEcosystem/python-crypto)
-* [https://github.com/ARKEcosystem/ruby-crypto](https://github.com/ARKEcosystem/ruby-crypto)
+* [https://github.com/ArkEcosystem/php-crypto](https://github.com/ArkEcosystem/php-crypto)
+* [https://github.com/ArkEcosystem/python-crypto](https://github.com/ArkEcosystem/python-crypto)
+* [https://github.com/ArkEcosystem/ruby-crypto](https://github.com/ArkEcosystem/ruby-crypto)
 
 ### Functional Programming
 
-* [https://github.com/ARKEcosystem/elixir-crypto](https://github.com/ARKEcosystem/elixir-crypto)
-* [https://github.com/ARKEcosystem/go-crypto](https://github.com/ARKEcosystem/go-crypto)
+* [https://github.com/ArkEcosystem/elixir-crypto](https://github.com/ArkEcosystem/elixir-crypto)
+* [https://github.com/ArkEcosystem/go-crypto](https://github.com/ArkEcosystem/go-crypto)

--- a/docs/sdk/java/client/getting-started.md.blade.php
+++ b/docs/sdk/java/client/getting-started.md.blade.php
@@ -50,7 +50,7 @@ Once installed, you can edit the `pom.xml` file of the project and add the follo
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/java-client).
+1. Fork the [package](https://github.com/ArkEcosystem/java-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/java/client/intro.md.blade.php
+++ b/docs/sdk/java/client/intro.md.blade.php
@@ -42,7 +42,7 @@ mvn install
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/java-client).
+1. Fork the [package](https://github.com/ArkEcosystem/java-client).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/java/crypto/getting-started.md.blade.php
+++ b/docs/sdk/java/crypto/getting-started.md.blade.php
@@ -50,7 +50,7 @@ Once installed, you can edit the `pom.xml` file of the project and add the follo
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/java-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/java-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/java/crypto/intro.md.blade.php
+++ b/docs/sdk/java/crypto/intro.md.blade.php
@@ -42,7 +42,7 @@ mvn install
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/java-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/java-crypto).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/javascript/client/intro.md.blade.php
+++ b/docs/sdk/javascript/client/intro.md.blade.php
@@ -12,7 +12,7 @@ yarn add @arkecosystem/client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/javascript-client).
+1. Fork the [package](https://github.com/ArkEcosystem/javascript-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/javascript/crypto/intro.md.blade.php
+++ b/docs/sdk/javascript/crypto/intro.md.blade.php
@@ -12,7 +12,7 @@ yarn add @arkecosystem/crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/javascript-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/javascript-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/php/client/examples.md.blade.php
+++ b/docs/sdk/php/client/examples.md.blade.php
@@ -7,7 +7,7 @@ title: Examples
 ## Initialization
 
 ```php
-use ARKEcosystem\Client\Connection;
+use ArkEcosystem\Client\Connection;
 
 $connection = new Connection([
     'host' => 'http://my.ark.node:port/api/',

--- a/docs/sdk/php/client/getting-started.md.blade.php
+++ b/docs/sdk/php/client/getting-started.md.blade.php
@@ -32,7 +32,7 @@ composer require arkecosystem/client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/php-client).
+1. Fork the [package](https://github.com/ArkEcosystem/php-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/php/client/intro.md.blade.php
+++ b/docs/sdk/php/client/intro.md.blade.php
@@ -18,7 +18,7 @@ composer require arkecosystem/client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/php-client).
+1. Fork the [package](https://github.com/ArkEcosystem/php-client).
 2. Clone forked repository.
 
 ```bash

--- a/docs/sdk/php/crypto/examples.md.blade.php
+++ b/docs/sdk/php/crypto/examples.md.blade.php
@@ -7,7 +7,7 @@ title: Examples
 ## Initialization
 
 ```php
-use ARKEcosystem\Crypto\Transactions\Builder\Transfer;
+use ArkEcosystem\Crypto\Transactions\Builder\Transfer;
 ```
 
 ## Transactions
@@ -35,7 +35,7 @@ echo gettype($transaction);
 > Serialization of a transaction object ensures it is compact and properly formatted to be incorporated in the ARK blockchain. If you are using the crypto SDK in combination with the public API SDK, you should not need to serialize manually.
 
 ```php
-use ARKEcosystem\Crypto\Transactions\Serializer;
+use ArkEcosystem\Crypto\Transactions\Serializer;
 
 $buffer = Serializer::new($transaction)->serialize();
 
@@ -49,7 +49,7 @@ echo gettype($buffer);
 > A serialized transaction may be deserialized for inspection purposes. The public API does not return serialized transactions, so you should only need to deserialize in exceptional circumstances.
 
 ```php
-use ARKEcosystem\Crypto\Transactions\Deserializer;
+use ArkEcosystem\Crypto\Transactions\Deserializer;
 
 $transaction = Deserializer::new($serializedTransaction)->deserialize();
 
@@ -67,7 +67,7 @@ The crypto SDK not only supports transactions but can also work with other arbit
 > Signing a string works much like signing a transaction: in most implementations, the message is hashed, and the resulting hash is signed using the `private key` or `passphrase`.
 
 ```php
-use ARKEcosystem\Crypto\Utils\Message;
+use ArkEcosystem\Crypto\Utils\Message;
 
 $message = Message::sign('Hello World', 'this is a top secret passphrase');
 
@@ -81,7 +81,7 @@ echo gettype($message);
 > A message's signature can easily be verified by hash, without the private key that signed the message, by using the `verify` method.
 
 ```php
-use ARKEcosystem\Crypto\Utils\Message;
+use ArkEcosystem\Crypto\Utils\Message;
 
 $message = Message::new([
     'publickey' => 'validPublicKey',
@@ -101,7 +101,7 @@ echo($message->verify() ? 'Valid' : 'Invalid');
 ### Derive the Address from a Passphrase
 
 ```php
-use ARKEcosystem\Crypto\Identities\Address;
+use ArkEcosystem\Crypto\Identities\Address;
 
 $address = Address::fromPassphrase('this is a top secret passphrase');
 
@@ -113,7 +113,7 @@ echo gettype($address);
 ### Derive the Address from a Public Key
 
 ```php
-use ARKEcosystem\Crypto\Identities\Address;
+use ArkEcosystem\Crypto\Identities\Address;
 
 $address = Address::fromPublicKey('validPublicKey');
 
@@ -125,7 +125,7 @@ echo gettype($address);
 ### Derive the Address from a Private Key
 
 ```php
-use ARKEcosystem\Crypto\Identities\Address;
+use ArkEcosystem\Crypto\Identities\Address;
 
 $address = Address::fromPrivateKey('validPrivateKey');
 
@@ -137,7 +137,7 @@ echo gettype($address);
 ### Validate an Address
 
 ```php
-use ARKEcosystem\Crypto\Identities\Address;
+use ArkEcosystem\Crypto\Identities\Address;
 
 $address = Address::validate('validAddress');
 
@@ -153,7 +153,7 @@ echo gettype($address);
 ### Derive the Private Key from a Passphrase
 
 ```php
-use ARKEcosystem\Crypto\Identities\PrivateKey;
+use ArkEcosystem\Crypto\Identities\PrivateKey;
 
 $privateKey = PrivateKey::fromPassphrase('this is a top secret passphrase');
 
@@ -165,7 +165,7 @@ echo gettype($privateKey);
 ### Derive the Private Key Instance Object from a Hexadecimal Encoded String
 
 ```php
-use ARKEcosystem\Crypto\Identities\PrivateKey;
+use ArkEcosystem\Crypto\Identities\PrivateKey;
 
 $privateKey = PrivateKey::fromHex('validHexString');
 
@@ -178,7 +178,7 @@ echo gettype($privateKey);
 ### Derive the Private Key from a WIF
 
 ```php
-use ARKEcosystem\Crypto\Identities\PrivateKey;
+use ArkEcosystem\Crypto\Identities\PrivateKey;
 
 $privateKey = PrivateKey::fromWif('validWif');
 
@@ -194,7 +194,7 @@ echo gettype($privateKey);
 ### Derive the Public Key from a Passphrase
 
 ```php
-use ARKEcosystem\Crypto\Identities\PublicKey;
+use ArkEcosystem\Crypto\Identities\PublicKey;
 
 $publicKey = PublicKey::fromPassphrase('this is a top secret passphrase');
 
@@ -206,7 +206,7 @@ echo gettype($publicKey);
 ### Derive the Public Key Instance Object from a Hexadecimal Encoded String
 
 ```php
-use ARKEcosystem\Crypto\Identities\PublicKey;
+use ArkEcosystem\Crypto\Identities\PublicKey;
 
 $publicKey = PublicKey::fromHex('validHexString');
 
@@ -218,7 +218,7 @@ echo gettype($publicKey);
 ### Validate a Public Key
 
 ```php
-use ARKEcosystem\Crypto\Identities\PublicKey;
+use ArkEcosystem\Crypto\Identities\PublicKey;
 
 $publicKey = PublicKey::validate('validPublicKey');
 
@@ -234,7 +234,7 @@ echo gettype($publicKey);
 ### Derive the WIF from a Passphrase
 
 ```php
-use ARKEcosystem\Crypto\Identities\WIF;
+use ArkEcosystem\Crypto\Identities\WIF;
 
 $wif = WIF::fromPassphrase('this is a top secret passphrase');
 

--- a/docs/sdk/php/crypto/getting-started.md.blade.php
+++ b/docs/sdk/php/crypto/getting-started.md.blade.php
@@ -32,7 +32,7 @@ composer require arkecosystem/crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/php-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/php-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/php/crypto/intro.md.blade.php
+++ b/docs/sdk/php/crypto/intro.md.blade.php
@@ -18,7 +18,7 @@ composer require arkecosystem/crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/php-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/php-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/php/frameworks/laravel.md.blade.php
+++ b/docs/sdk/php/frameworks/laravel.md.blade.php
@@ -15,7 +15,7 @@ composer require arkecosystem/laravel
 ARK Laravel requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-php artisan vendor:publish --provider="ARKEcosystem\ARK\ARKServiceProvider"
+php artisan vendor:publish --provider="ArkEcosystem\Ark\ArkServiceProvider"
 ```
 
 This will create a `config/ark.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.
@@ -30,15 +30,15 @@ This option `connections` is where each of the connections is set up for your ap
 
 ## Usage
 
-### ARKManager
+### ArkManager
 
-This is the class of most interest. It is bound to the ioc container as `ark` and can be accessed using the `Facades\ARK` facade. This class implements the ManagerInterface by extending AbstractManager. The interface and abstract class are both part of [Graham Campbell's](https://github.com/GrahamCampbell) [Laravel Manager](https://github.com/GrahamCampbell/Laravel-Manager) package, so you may want to go and check out the docs for how to use the manager class over at that repository. Note that the connection class returned will always be an instance of `ARK\ARK`.
+This is the class of most interest. It is bound to the ioc container as `ark` and can be accessed using the `Facades\Ark` facade. This class implements the ManagerInterface by extending AbstractManager. The interface and abstract class are both part of [Graham Campbell's](https://github.com/GrahamCampbell) [Laravel Manager](https://github.com/GrahamCampbell/Laravel-Manager) package, so you may want to go and check out the docs for how to use the manager class over at that repository. Note that the connection class returned will always be an instance of `Ark\Ark`.
 
-### Facades\ARK
+### Facades\Ark
 
-This facade will dynamically pass static method calls to the `ark` object in the ioc container which by default is the `ARKManager` class.
+This facade will dynamically pass static method calls to the `ark` object in the ioc container which by default is the `ArkManager` class.
 
-### ARKServiceProvider
+### ArkServiceProvider
 
 _This class contains no public methods of interest, it should be added to the providers array in `config/app.php` as it sets up ioc bindings._
 
@@ -48,43 +48,43 @@ Here you can see an example of just how simple this package is to use. Out of th
 
 ```php
 // You can alias this in config/app.php.
-use ARKEcosystem\ARK\Facades\ARK;
+use ArkEcosystem\Ark\Facades\Ark;
 
-ARK::api('Wallets')->wallets();
+Ark::api('Wallets')->wallets();
 // We're done here - how easy was that, it just works!
 ```
 
-The ARK manager will behave like it is an `ARKEcosystem\ARK\Client`. If you want to call specific connections, you can do that with the connection method:
+The ARK manager will behave like it is an `ArkEcosystem\Ark\Client`. If you want to call specific connections, you can do that with the connection method:
 
 ```php
-use ARKEcosystem\ARK\Facades\ARK;
+use ArkEcosystem\Ark\Facades\Ark;
 
 // Writing this…
-ARK::connection('main')->api('Wallets')->all();
+Ark::connection('main')->api('Wallets')->all();
 
 // …is identical to writing this
-ARK::api('Wallets')->all();
+Ark::api('Wallets')->all();
 
 // and is also identical to writing this.
-ARK::connection()->api('Wallets')->all();
+Ark::connection()->api('Wallets')->all();
 
 // This is because the main connection is configured to be the default.
-ARK::getDefaultConnection(); // This will return main.
+Ark::getDefaultConnection(); // This will return main.
 
 // We can change the default connection.
-ARK::setDefaultConnection('alternative'); // The default is now alternative.
+Ark::setDefaultConnection('alternative'); // The default is now alternative.
 ```
 
 If you prefer to use dependency injection over facades like me, then you can inject the manager:
 
 ```php
-use ARKEcosystem\ARK\ARKManager;
+use ArkEcosystem\Ark\ArkManager;
 
 class Foo
 {
     protected $ark;
 
-    public function __construct(ARKManager $ark)
+    public function __construct(ArkManager $ark)
     {
         $this->ark = $ark;
     }
@@ -100,4 +100,4 @@ App::make('Foo')->bar($params);
 
 ## API Documentation
 
-There are other classes in this package that are not documented here. This is because the package is a Laravel wrapper of [the ARK php-client package](https://github.com/ARKEcosystem/php-client).
+There are other classes in this package that are not documented here. This is because the package is a Laravel wrapper of [the ARK php-client package](https://github.com/ArkEcosystem/php-client).

--- a/docs/sdk/php/frameworks/symfony.md.blade.php
+++ b/docs/sdk/php/frameworks/symfony.md.blade.php
@@ -16,7 +16,7 @@ Go to `config/packages/ark.yml` and fill out your configuration similar to this.
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     // ...
-    ARKEcosystem\ARKBundle\ARKBundle::class => ['all' => true],
+    ArkEcosystem\ArkBundle\ArkBundle::class => ['all' => true],
 ];
 ```
 
@@ -59,4 +59,4 @@ class CoolStuffController extends Controller
 
 ## API Documentation
 
-There are other classes in this package that are not documented here. This is because the package is a Laravel wrapper of [the ARK php-client package](https://github.com/ARKEcosystem/php-client).
+There are other classes in this package that are not documented here. This is because the package is a Laravel wrapper of [the ARK php-client package](https://github.com/ArkEcosystem/php-client).

--- a/docs/sdk/python/client/getting-started.md.blade.php
+++ b/docs/sdk/python/client/getting-started.md.blade.php
@@ -90,7 +90,7 @@ pip install arkecosystem-client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/python-client).
+1. Fork the [package](https://github.com/ArkEcosystem/python-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/python/client/intro.md.blade.php
+++ b/docs/sdk/python/client/intro.md.blade.php
@@ -12,7 +12,7 @@ pip install arkecosystem-client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/python-client).
+1. Fork the [package](https://github.com/ArkEcosystem/python-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/python/crypto/getting-started.md.blade.php
+++ b/docs/sdk/python/crypto/getting-started.md.blade.php
@@ -90,7 +90,7 @@ pip install arkecosystem-crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/python-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/python-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/python/crypto/intro.md.blade.php
+++ b/docs/sdk/python/crypto/intro.md.blade.php
@@ -12,7 +12,7 @@ pip install arkecosystem-crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/python-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/python-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/ruby/client/examples.md.blade.php
+++ b/docs/sdk/ruby/client/examples.md.blade.php
@@ -9,9 +9,9 @@ title: Examples
 ```ruby
 require 'arkecosystem/client'
 
-manager = ARKEcosystem::Client::ConnectionManager.new()
+manager = ArkEcosystem::Client::ConnectionManager.new()
 
-connection = manager.connect(ARKEcosystem::Client::Connection.new({
+connection = manager.connect(ArkEcosystem::Client::Connection.new({
   host: "http://my.ark.node:port/api/"
 }), 'main')
 ```

--- a/docs/sdk/ruby/client/getting-started.md.blade.php
+++ b/docs/sdk/ruby/client/getting-started.md.blade.php
@@ -33,7 +33,7 @@ gem install arkecosystem-client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/ruby-client).
+1. Fork the [package](https://github.com/ArkEcosystem/ruby-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/ruby/client/intro.md.blade.php
+++ b/docs/sdk/ruby/client/intro.md.blade.php
@@ -20,7 +20,7 @@ gem install arkecosystem-client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/ruby-client).
+1. Fork the [package](https://github.com/ArkEcosystem/ruby-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/ruby/crypto/examples.md.blade.php
+++ b/docs/sdk/ruby/crypto/examples.md.blade.php
@@ -9,7 +9,7 @@ title: Examples
 ```ruby
 require 'arkecosystem/crypto'
 
-transaction = ARKEcosystem::Crypto::Transactions::Builder::Transfer.new()
+transaction = ArkEcosystem::Crypto::Transactions::Builder::Transfer.new()
   .set_recipient_id('validAddress')
   .set_amount(1 * 10 ** 8)
   .set_vendor_field('This is a transaction from Ruby')
@@ -25,7 +25,7 @@ A transaction is an object specifying the transfer of funds from the sender's wa
 The crypto SDK can sign a transaction using your private key or passphrase (from which the private key is generated). Ensure you are familiar with [digital signatures](https://en.wikipedia.org/wiki/Digital_signature) before using the crypto SDKs.
 
 ```ruby
-transaction = ARKEcosystem::Crypto::Transactions::Builder::Transfer.new()
+transaction = ArkEcosystem::Crypto::Transactions::Builder::Transfer.new()
   .set_recipient_id('validAddress')
   .set_amount(1 * 10 ** 8)
   .set_vendor_field('This is a transaction from Ruby')
@@ -41,7 +41,7 @@ print transaction.class
 > Serialization of a transaction object ensures it is compact and properly formatted to be incorporated in the ARK blockchain. If you are using the crypto SDK in combination with the public API SDK, you should not need to serialize manually.
 
 ```ruby
-serializer = ARKEcosystem::Crypto::Transactions::Serializer.new(transaction)
+serializer = ArkEcosystem::Crypto::Transactions::Serializer.new(transaction)
 
 print serializer.class
 
@@ -53,7 +53,7 @@ print serializer.class
 > A serialized transaction may be deserialized for inspection purposes. The public API does not return serialized transactions, so you should only need to deserialize in exceptional circumstances.
 
 ```ruby
-deserializer = ARKEcosystem::Crypto::Transactions::Deserializer.new(serialized_transaction)
+deserializer = ArkEcosystem::Crypto::Transactions::Deserializer.new(serialized_transaction)
 
 print deserializer.class
 
@@ -69,7 +69,7 @@ The crypto SDK not only supports transactions but can also work with other arbit
 > Signing a string works much like signing a transaction: in most implementations, the message is hashed, and the resulting hash is signed using the `private key` or `passphrase`.
 
 ```ruby
-message = ARKEcosystem::Crypto::Utils::Message.sign('Hello World', 'this is a top secret passphrase')
+message = ArkEcosystem::Crypto::Utils::Message.sign('Hello World', 'this is a top secret passphrase')
 
 print message.class
 
@@ -81,7 +81,7 @@ print message.class
 > A message's signature can easily be verified by hash, without the private key that signed the message, by using the `verify` method.
 
 ```ruby
-message = ARKEcosystem::Crypto::Utils::Message.new(
+message = ArkEcosystem::Crypto::Utils::Message.new(
   publickey: 'validPublicKey',
   signature: 'validSignature',
   message: 'Hello World'
@@ -99,7 +99,7 @@ print message.class
 ### Derive the Address from a Passphrase
 
 ```ruby
-address = ARKEcosystem::Crypto::Identities::Address.from_passphrase('this is a top secret passphrase')
+address = ArkEcosystem::Crypto::Identities::Address.from_passphrase('this is a top secret passphrase')
 
 print address.class
 
@@ -109,7 +109,7 @@ print address.class
 ### Derive the Address from a Public Key
 
 ```ruby
-address = ARKEcosystem::Crypto::Identities::Address.from_public_key('validPublicKey')
+address = ArkEcosystem::Crypto::Identities::Address.from_public_key('validPublicKey')
 
 print address.class
 
@@ -119,7 +119,7 @@ print address.class
 ### Derive the Address from a Private Key
 
 ```ruby
-address = ARKEcosystem::Crypto::Identities::Address.from_private_key('validPrivateKey')
+address = ArkEcosystem::Crypto::Identities::Address.from_private_key('validPrivateKey')
 
 print address.class
 
@@ -129,7 +129,7 @@ print address.class
 ### Validate an Address
 
 ```ruby
-address = ARKEcosystem::Crypto::Identities::Address.validate('validAddress')
+address = ArkEcosystem::Crypto::Identities::Address.validate('validAddress')
 
 print address.class
 
@@ -143,7 +143,7 @@ print address.class
 ### Derive the Private Key from a Passphrase
 
 ```ruby
-privateKey = ARKEcosystem::Crypto::Identities::PrivateKey.from_passphrase('this is a top secret passphrase')
+privateKey = ArkEcosystem::Crypto::Identities::PrivateKey.from_passphrase('this is a top secret passphrase')
 
 print privateKey.class
 
@@ -153,7 +153,7 @@ print privateKey.class
 ### Derive the Private Key Instance Object from a Hexadecimal Encoded String
 
 ```ruby
-privateKey = ARKEcosystem::Crypto::Identities::PrivateKey.from_hex('validHexString')
+privateKey = ArkEcosystem::Crypto::Identities::PrivateKey.from_hex('validHexString')
 
 print privateKey.class
 
@@ -173,7 +173,7 @@ This function has not been implemented in this client library.
 ### Derive the Public Key from a Passphrase
 
 ```ruby
-publicKey = ARKEcosystem::Crypto::Identities::PublicKey.from_passphrase('this is a top secret passphrase')
+publicKey = ArkEcosystem::Crypto::Identities::PublicKey.from_passphrase('this is a top secret passphrase')
 
 print publicKey.class
 
@@ -183,7 +183,7 @@ print publicKey.class
 ### Derive the Public Key Instance Object from a Hexadecimal Encoded String
 
 ```ruby
-publicKey = ARKEcosystem::Crypto::Identities::PublicKey.from_hex('validHexString')
+publicKey = ArkEcosystem::Crypto::Identities::PublicKey.from_hex('validHexString')
 
 print publicKey.class
 
@@ -203,7 +203,7 @@ This function has not been implemented in this client library.
 ### Derive the WIF from a Passphrase
 
 ```ruby
-wif = ARKEcosystem::Crypto::Identities::WIF.from_passphrase('this is a top secret passphrase')
+wif = ArkEcosystem::Crypto::Identities::WIF.from_passphrase('this is a top secret passphrase')
 
 print wif.class
 

--- a/docs/sdk/ruby/crypto/getting-started.md.blade.php
+++ b/docs/sdk/ruby/crypto/getting-started.md.blade.php
@@ -33,7 +33,7 @@ gem install arkecosystem-crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/ruby-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/ruby-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/ruby/crypto/intro.md.blade.php
+++ b/docs/sdk/ruby/crypto/intro.md.blade.php
@@ -20,7 +20,7 @@ gem install arkecosystem-crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/ruby-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/ruby-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/rust/client/getting-started.md.blade.php
+++ b/docs/sdk/rust/client/getting-started.md.blade.php
@@ -21,14 +21,14 @@ Add the following to your `Cargo.toml`:
 
 ```ini
 [dependencies]
-arkecosystem-client = {git = "https://github.com/ARKEcosystem/rust-client", branch = "master" }
+arkecosystem-client = {git = "https://github.com/ArkEcosystem/rust-client", branch = "master" }
 ```
 
 You can now run `cargo build`, and Cargo will fetch the new dependencies and all of their dependencies.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/rust-client).
+1. Fork the [package](https://github.com/ArkEcosystem/rust-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/rust/client/intro.md.blade.php
+++ b/docs/sdk/rust/client/intro.md.blade.php
@@ -10,14 +10,14 @@ Add the following to your `Cargo.toml`:
 
 ```text
 [dependencies]
-arkecosystem-client = {git = "https://github.com/ARKEcosystem/rust-client", branch = "master" }
+arkecosystem-client = {git = "https://github.com/ArkEcosystem/rust-client", branch = "master" }
 ```
 
 You can now run `cargo build`, and Cargo will fetch the new dependencies and all of their dependencies.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/rust-client).
+1. Fork the [package](https://github.com/ArkEcosystem/rust-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/rust/crypto/getting-started.md.blade.php
+++ b/docs/sdk/rust/crypto/getting-started.md.blade.php
@@ -22,14 +22,14 @@ Add the following to your `Cargo.toml`:
 
 ```ini
 [dependencies]
-arkecosystem-crypto = {git = "https://github.com/ARKEcosystem/rust-crypto", branch = "master" }
+arkecosystem-crypto = {git = "https://github.com/ArkEcosystem/rust-crypto", branch = "master" }
 ```
 
 You can now run `cargo build`, and Cargo will fetch the new dependencies and all of their dependencies.s
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/rust-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/rust-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/rust/crypto/intro.md.blade.php
+++ b/docs/sdk/rust/crypto/intro.md.blade.php
@@ -10,14 +10,14 @@ Add the following to your `Cargo.toml`:
 
 ```text
 [dependencies]
-arkecosystem-crypto = {git = "https://github.com/ARKEcosystem/rust-crypto", branch = "master" }
+arkecosystem-crypto = {git = "https://github.com/ArkEcosystem/rust-crypto", branch = "master" }
 ```
 
 You can now run `cargo build`, and Cargo will fetch the new dependencies and all of their dependencies.s
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/rust-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/rust-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/swift/client/getting-started.md.blade.php
+++ b/docs/sdk/swift/client/getting-started.md.blade.php
@@ -28,14 +28,14 @@ To install CocoaPods, head over  to the official [guide](https://guides.cocoapod
 To integrate the ARK Swift Client in your project, add the following content to your `Podfile` :
 
 ```pod
-'SwiftClient', :git => 'https://github.com/ARKEcosystem/swift-client.git', :tag => '1.0.1'
+'SwiftClient', :git => 'https://github.com/ArkEcosystem/swift-client.git', :tag => '1.0.1'
 ```
 
 Afterward, install it by running `pod install`.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/swift-client).
+1. Fork the [package](https://github.com/ArkEcosystem/swift-client).
 
 2. Clone your forked repository.
 
@@ -70,4 +70,4 @@ Dependencies are now installed, you can now run the tests to see if everything i
 By default, the requests are performed with [Alamofire](https://github.com/Alamofire/Alamofire), and the response is given to the callback function as `[String: Any]`.
 The functions that are responsible for this can be found in `Utils.swift`.
 You can easily override this default functionality by defining your own `handleApiGet` and `handleApiPost` functions and passing them to the endpoint object (e.g. `Blocks`.
-An example of how this is done can be found by looking at the tests, e.g. those of [Blocks](https://github.com/ARKEcosystem/swift-client/blob/master/Client/ClientTests/Api/Endpoints/BlocksTest.swift), as a mocked api handler is used for them.
+An example of how this is done can be found by looking at the tests, e.g. those of [Blocks](https://github.com/ArkEcosystem/swift-client/blob/master/Client/ClientTests/Api/Endpoints/BlocksTest.swift), as a mocked api handler is used for them.

--- a/docs/sdk/swift/client/intro.md.blade.php
+++ b/docs/sdk/swift/client/intro.md.blade.php
@@ -9,14 +9,14 @@ title: Getting Started
 To integrate the ARK Swift Client in your project, add the following content to your `Podfile` :
 
 ```text
-'SwiftClient', :git => 'https://github.com/ARKEcosystem/swift-client.git', :tag => '1.0.1'
+'SwiftClient', :git => 'https://github.com/ArkEcosystem/swift-client.git', :tag => '1.0.1'
 ```
 
 Afterward, install it by running `pod install`.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/swift-client).
+1. Fork the [package](https://github.com/ArkEcosystem/swift-client).
 2. Clone your forked repository.
 
 ```bash
@@ -47,4 +47,4 @@ Dependencies are now installed, you can now run the tests to see if everything i
 
 ### Additional Information
 
-By default, the requests are performed with [Alamofire](https://github.com/Alamofire/Alamofire), and the response is given to the callback function as `[String: Any]`. The functions that are responsible for this can be found in `Utils.swift`. You can easily override this default functionality by defining your own `handleApiGet` and `handleApiPost` functions and passing them to the endpoint object (e.g. `Blocks`. An example of how this is done can be found by looking at the tests, e.g. those of [Blocks](https://github.com/ARKEcosystem/swift-client/blob/master/Client/ClientTests/Api/Endpoints/BlocksTest.swift), as a mocked api handler is used for them.
+By default, the requests are performed with [Alamofire](https://github.com/Alamofire/Alamofire), and the response is given to the callback function as `[String: Any]`. The functions that are responsible for this can be found in `Utils.swift`. You can easily override this default functionality by defining your own `handleApiGet` and `handleApiPost` functions and passing them to the endpoint object (e.g. `Blocks`. An example of how this is done can be found by looking at the tests, e.g. those of [Blocks](https://github.com/ArkEcosystem/swift-client/blob/master/Client/ClientTests/Api/Endpoints/BlocksTest.swift), as a mocked api handler is used for them.

--- a/docs/sdk/swift/crypto/examples.md.blade.php
+++ b/docs/sdk/swift/crypto/examples.md.blade.php
@@ -20,7 +20,7 @@ The crypto SDK can sign a transaction using your private key or passphrase (from
 
 ```swift
 // Creating a transaction automatically signs it with the provides passphrase(s)
-let transfer = ARKBuilder.buildTransfer(
+let transfer = ArkBuilder.buildTransfer(
     "secret passphrase",
     secondPassphrase: nil,
     to: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8",
@@ -37,7 +37,7 @@ print(type(of: transfer))
 > Serialization of a transaction object ensures it is compact and properly formatted to be incorporated in the ARK blockchain. If you are using the crypto SDK in combination with the public API SDK, you should not need to serialize manually.
 
 ```swift
-let serialized = ARKSerializer.serialize(transaction: transaction)
+let serialized = ArkSerializer.serialize(transaction: transaction)
 
 print(type(of: serialized))
 
@@ -49,7 +49,7 @@ print(type(of: serialized))
 > A serialized transaction may be deserialized for inspection purposes. The public API does not return serialized transactions, so you should only need to deserialize in exceptional circumstances.
 
 ```swift
-let deserialized = ARKDeserializer.deserialize(serialized: serialized)
+let deserialized = ArkDeserializer.deserialize(serialized: serialized)
 
 print(type(of: deserialized))
 
@@ -65,7 +65,7 @@ The crypto SDK not only supports transactions but can also work with other arbit
 > Signing a string works much like signing a transaction: in most implementations, the message is hashed, and the resulting hash is signed using the `private key` or `passphrase`.
 
 ```swift
-let message = ARKMessage.sign(message: "Hello World", passphrase: "this is a top secret passphrase")
+let message = ArkMessage.sign(message: "Hello World", passphrase: "this is a top secret passphrase")
 
 print(type(of: message))
 
@@ -77,7 +77,7 @@ print(type(of: message))
 > A message's signature can easily be verified by hash, without the private key that signed the message, by using the `verify` method.
 
 ```swift
-let message = ARKMessage(publicKey: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
+let message = ArkMessage(publicKey: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
                          signature: "304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8",
                          message: "Hello World")
 
@@ -93,7 +93,7 @@ print(type(of: message.verify()))
 ### Derive the Address from a Passphrase
 
 ```swift
-let address = ARKAddress.from(passphrase: "this is a top secret passphrase")
+let address = ArkAddress.from(passphrase: "this is a top secret passphrase")
 
 print(type(of: address))
 
@@ -103,7 +103,7 @@ print(type(of: address))
 ### Derive the Address from a Public Key
 
 ```swift
-let address = ARKAddress.from(publicKey: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192")
+let address = ArkAddress.from(publicKey: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192")
 
 print(type(of: address))
 
@@ -113,7 +113,7 @@ print(type(of: address))
 ### Derive the Address from a Private Key
 
 ```swift
-let address = ARKAddress.from(privateKey: ARKPrivateKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712"))
+let address = ArkAddress.from(privateKey: ArkPrivateKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712"))
 
 print(type(of: address))
 
@@ -123,7 +123,7 @@ print(type(of: address))
 ### Validate an Address
 
 ```swift
-let address = ARKAddress.validate(address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")
+let address = ArkAddress.validate(address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")
 
 print(type(of: address))
 
@@ -137,7 +137,7 @@ print(type(of: address))
 ### Derive the Private Key from a Passphrase
 
 ```swift
-let privateKey = ARKPrivateKey.from(passphrase: "this is a top secret passphrase")
+let privateKey = ArkPrivateKey.from(passphrase: "this is a top secret passphrase")
 
 print(type(of: privateKey))
 
@@ -147,7 +147,7 @@ print(type(of: privateKey))
 ### Derive the Private Key Instance Object from a Hexadecimal Encoded String
 
 ```swift
-let privateKey = ARKPrivateKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712")
+let privateKey = ArkPrivateKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712")
 
 print(type(of: privateKey))
 
@@ -167,7 +167,7 @@ This function has not been implemented in this client library.
 ### Derive the Public Key from a Passphrase
 
 ```swift
-let publicKey = ARKPublicKey.from(passphrase: "this is a top secret passphrase")
+let publicKey = ArkPublicKey.from(passphrase: "this is a top secret passphrase")
 
 print(type(of: publicKey))
 
@@ -177,7 +177,7 @@ print(type(of: publicKey))
 ### Derive the Public Key Instance Object from a Hexadecimal Encoded String
 
 ```swift
-let publicKey = ARKPublicKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712")
+let publicKey = ArkPublicKey.from(hex: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712")
 
 print(type(of: publicKey))
 

--- a/docs/sdk/swift/crypto/getting-started.md.blade.php
+++ b/docs/sdk/swift/crypto/getting-started.md.blade.php
@@ -28,14 +28,14 @@ To install CocoaPods, head over  to the official [guide](https://guides.cocoapod
 To integrate the ARK Swift Crypto in your project, add the following content to your `Podfile` :
 
 ```pod
-'SwiftCrypto', :git => 'https://github.com/ARKEcosystem/swift-crypto.git', :tag => '1.0.1'
+'SwiftCrypto', :git => 'https://github.com/ArkEcosystem/swift-crypto.git', :tag => '1.0.1'
 ```
 
 Afterward, install it by running `pod install`.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/swift-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/swift-crypto).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/swift/crypto/intro.md.blade.php
+++ b/docs/sdk/swift/crypto/intro.md.blade.php
@@ -9,14 +9,14 @@ title: Getting Started
 To integrate the ARK Swift Crypto in your project, add the following content to your `Podfile` :
 
 ```text
-'SwiftCrypto', :git => 'https://github.com/ARKEcosystem/swift-crypto.git', :tag => '1.0.1'
+'SwiftCrypto', :git => 'https://github.com/ArkEcosystem/swift-crypto.git', :tag => '1.0.1'
 ```
 
 Afterward, install it by running `pod install`.
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/swift-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/swift-crypto).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/typescript/client/getting-started.md.blade.php
+++ b/docs/sdk/typescript/client/getting-started.md.blade.php
@@ -26,7 +26,7 @@ yarn add @arkecosystem/client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/javascript-client).
+1. Fork the [package](https://github.com/ArkEcosystem/javascript-client).
 
 2. Clone your forked repository.
 

--- a/docs/sdk/typescript/client/intro.md.blade.php
+++ b/docs/sdk/typescript/client/intro.md.blade.php
@@ -12,7 +12,7 @@ yarn add @arkecosystem/client
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/javascript-client).
+1. Fork the [package](https://github.com/ArkEcosystem/javascript-client).
 2. Clone your forked repository.
 
 ```bash

--- a/docs/sdk/typescript/crypto/getting-started.md.blade.php
+++ b/docs/sdk/typescript/crypto/getting-started.md.blade.php
@@ -26,7 +26,7 @@ yarn add @arkecosystem/crypto
 
 ## Development
 
-1. Fork the [package](https://github.com/ARKEcosystem/javascript-crypto).
+1. Fork the [package](https://github.com/ArkEcosystem/javascript-crypto).
 
 2. Clone your forked repository.
 


### PR DESCRIPTION

## Summary

Use correct casing for "Ark" in code examples and git repo URLs.

## Checklist

- [x] Tests
- [x] Ready to be merged
