### PR TITLE
fix(desktop-wallet): rewards typo

### DIFF
--- a/docs/desktop-wallet/introduction-to-ark-rewards.md.blade.php
+++ b/docs/desktop-wallet/introduction-to-ark-rewards.md.blade.php
@@ -4,7 +4,7 @@ title: An Introduction to ARK Rewards (Staking)
 
 # An Introduction to ARK Rewards (Staking)
 
-The ARK Public Network (APN) is a sovereign Blockchain with a native Cryptoasset called ARK. It is based on the Delegated-Prof-of-Stake (DPoS) consensus mechanism and has 51 active Delegates (Validators) who secure the network. In this article, we will discuss how block rewards work within the APN and how you can earn a portion of the rewards by becoming an active delegate or voting with your ARK coins.
+The ARK Public Network (APN) is a sovereign Blockchain with a native Cryptoasset called ARK. It is based on the Delegated-Proof-of-Stake (DPoS) consensus mechanism and has 51 active Delegates (Validators) who secure the network. In this article, we will discuss how block rewards work within the APN and how you can earn a portion of the rewards by becoming an active delegate or voting with your ARK coins.
 
 ## Staking Considerations
 


### PR DESCRIPTION

## Summary

Fix typo on the Desktop Wallet documentation's 'ARK Rewards' page.

`Delegated-Prof-of-Stake` => `Delegated-Proof-of-Stake`

## Checklist

- [x] Tests
- [x] Ready to be merged

## Additional Comments

Kebab-cased spelling may have played a roll in this sneaking past spellcheck 🤷‍♂️ 
