### PR TITLE
docs: better to place the warning before executing the command

### DIFF
--- a/docs/core/installation/script.md.blade.php
+++ b/docs/core/installation/script.md.blade.php
@@ -172,15 +172,15 @@ Press `y` and confirm with `enter`.
 
 Input the database credentials of your choosing.
 
+<x-alert type="warning">
+Replace `<network_name>` with the appropriate custom or pre-defined network name (e.g. '**ark_mainnet**', '**ark_devnet**', '**ark_testnet**').
+</x-alert>
+
 ```bash
 Enter the database username: ark
 Enter the database password: password
 Enter the database name: <network_name> # your chosen network name
 ```
-
-<x-alert type="warning">
-Replace `<network_name>` with the appropriate custom or pre-defined network name (e.g. '**ark_mainnet**', '**ark_devnet**', '**ark_testnet**').
-</x-alert>
 
 This will create a PostgreSQL role and database to be used for storing blockchain data.
 


### PR DESCRIPTION
## Summary
I think it's better to place this warning before executing the command.
I chose `devnet` in the command and then found out it should have been `ark_devnet`.

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
