### PR TITLE
refactor: remove top border on glossary and tutorials menu

### DIFF
--- a/docs/glossary/index.blade.php
+++ b/docs/glossary/index.blade.php
@@ -1,29 +1,29 @@
 <h3 class="pl-9 mt-4 pt-4 text-base font-semibold uppercase border-t text-theme-secondary-500 border-theme-secondary-200">Glossary</h3>
 
-<x-ark-docs-sidebar-link top-level path="#2" name="2" />
-<x-ark-docs-sidebar-link top-level path="#a" name="A" />
-<x-ark-docs-sidebar-link top-level path="#b" name="B" />
-<x-ark-docs-sidebar-link top-level path="#c" name="C" />
-<x-ark-docs-sidebar-link top-level path="#d" name="D" />
-<x-ark-docs-sidebar-link top-level path="#e" name="E" />
-<x-ark-docs-sidebar-link top-level path="#f" name="F" />
-<x-ark-docs-sidebar-link top-level path="#g" name="G" />
-<x-ark-docs-sidebar-link top-level path="#h" name="H" />
-<x-ark-docs-sidebar-link top-level path="#i" name="I" />
-<x-ark-docs-sidebar-link top-level path="#j" name="J" />
-<x-ark-docs-sidebar-link top-level path="#k" name="K" />
-<x-ark-docs-sidebar-link top-level path="#l" name="L" />
-<x-ark-docs-sidebar-link top-level path="#m" name="M" />
-<x-ark-docs-sidebar-link top-level path="#n" name="N" />
-<x-ark-docs-sidebar-link top-level path="#o" name="O" />
-<x-ark-docs-sidebar-link top-level path="#p" name="P" />
-<x-ark-docs-sidebar-link top-level path="#q" name="Q" />
-<x-ark-docs-sidebar-link top-level path="#r" name="R" />
-<x-ark-docs-sidebar-link top-level path="#s" name="S" />
-<x-ark-docs-sidebar-link top-level path="#t" name="T" />
-<x-ark-docs-sidebar-link top-level path="#u" name="U" />
-<x-ark-docs-sidebar-link top-level path="#v" name="V" />
-<x-ark-docs-sidebar-link top-level path="#w" name="W" />
-<x-ark-docs-sidebar-link top-level path="#x" name="X" />
-<x-ark-docs-sidebar-link top-level path="#y" name="Y" />
-<x-ark-docs-sidebar-link top-level path="#z" name="Z" />
+<x-ark-docs-sidebar-link top-level path="#2" name="2" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#a" name="A" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#b" name="B" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#c" name="C" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#d" name="D" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#e" name="E" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#f" name="F" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#g" name="G" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#h" name="H" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#i" name="I" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#j" name="J" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#k" name="K" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#l" name="L" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#m" name="M" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#n" name="N" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#o" name="O" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#p" name="P" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#q" name="Q" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#r" name="R" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#s" name="S" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#t" name="T" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#u" name="U" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#v" name="V" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#w" name="W" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#x" name="X" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#y" name="Y" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="#z" name="Z" :top-border="false" />

--- a/tutorials/ark-messenger-tutorial/index.blade.php
+++ b/tutorials/ark-messenger-tutorial/index.blade.php
@@ -1,4 +1,4 @@
-<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial" name="Introduction" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-one" name="Part One" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-two" name="Part Two" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-three" name="Part Three" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial" name="Introduction" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-one" name="Part One" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-two" name="Part Two" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/ark-messenger-tutorial/part-three" name="Part Three" :top-border="false" />

--- a/tutorials/launching-html5-games-in-the-ark-desktop-wallet/index.blade.php
+++ b/tutorials/launching-html5-games-in-the-ark-desktop-wallet/index.blade.php
@@ -1,7 +1,7 @@
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet" name="Introduction" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-one" name="Part One" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-two" name="Part Two" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-three" name="Part Three" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-four" name="Part Four" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-five" name="Part Five" />
-<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-six" name="Part Six" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet" name="Introduction" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-one" name="Part One" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-two" name="Part Two" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-three" name="Part Three" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-four" name="Part Four" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-five" name="Part Five" :top-border="false" />
+<x-ark-docs-sidebar-link top-level path="/tutorials/launching-html5-games-in-the-ark-desktop-wallet/part-six" name="Part Six" :top-border="false" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/2nh84uq and https://github.com/ArkEcosystem/ark.dev/pull/281

Removes the top border on the glossary menu added once we update ark.dev dependencies [on this PR](https://github.com/ArkEcosystem/ark.dev/pull/281):


### Before
![image](https://user-images.githubusercontent.com/17262776/182241571-0467d4ec-3af2-40c7-939b-47fc7631cb85.png)


### After
![image](https://user-images.githubusercontent.com/17262776/182241453-056f7d0d-aa8b-4880-9d71-0a1bc7cec2b8.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
